### PR TITLE
Fix old matlab contourc interface. Tested with shallow water on a sphere

### DIFF
--- a/src/matlab/create_patch.m
+++ b/src/matlab/create_patch.m
@@ -93,7 +93,7 @@ end;
 % Contour lines.
 userdata.contourLines = [];
 if (~isempty(contourlevels))
-  c = contourc(yc_like,zc_like,qcm2,contourlevels,'k');
+  c = contourc(yc_like,zc_like,qcm2,contourlevels);
   userdata.contourLines = create_clines(c,sval,sdir,mappedgrid,manifold);
 end;
 


### PR DESCRIPTION
This is a very easy fix for the contourc matlab interface. With new matlab releases, 
in line 96 of create_patch.m, i.e.  c = contourc(yc_like,zc_like,qcm2,contourlevels,'k');
the color option 'k' must be removed.

Thanks.
