### PR TITLE
Update visclaw to work with new Data and ClawData classes in clawutils.

### DIFF
--- a/src/python/visclaw/plotters/data.py
+++ b/src/python/visclaw/plotters/data.py
@@ -16,7 +16,7 @@ import os
 import copy
 import re
 import logging
-from pyclaw.data import Data
+from clawdata import Data, ClawData
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ class ClawPlotData(Data):
                            'plotitem_dict', 'html_movies', 'params']
 
         # Initialize the data object and read the data files
-        super(ClawPlotData,self).__init__(data_files,plot_attrs)
+        super(ClawPlotData,self).__init__(plot_attrs)
 
         # default values of attributes:
 
@@ -737,7 +737,7 @@ class ClawPlotAxes(Data):
 # ============================================================================
 #  Subclass ClawPlotItem containing data for plotting a single object
 # ============================================================================
-class ClawPlotItem(Data):
+class ClawPlotItem(ClawData):
     """
     
     Data subclass containing plot data needed to plot a single object.
@@ -757,7 +757,7 @@ class ClawPlotItem(Data):
                            'MappedGrid', 'mapc2p', \
                            'figno', 'handle', 'params', \
                            'aftergrid','afteritem','framesoln_dict', \
-                           '_pobjs']  
+                           '_pobjs','name','plot_type','plot_show','user','show']  
 
         super(ClawPlotItem, self).__init__(attributes = attributes)    
 

--- a/src/python/visclaw/plotters/frametools.py
+++ b/src/python/visclaw/plotters/frametools.py
@@ -11,7 +11,7 @@ import time
 import traceback
 
 
-from pyclaw.data import Data
+from clawdata import Data
 from visclaw.plotters import plotpages
 from matplotlib.colors import Normalize 
 

--- a/src/python/visclaw/plotters/gaugetools.py
+++ b/src/python/visclaw/plotters/gaugetools.py
@@ -8,7 +8,7 @@ import time
 import traceback
 
 
-from pyclaw.data import Data
+from clawdata import Data
 from visclaw.plotters import plotpages
 from visclaw.plotters.frametools import set_show
 


### PR DESCRIPTION
This is a minimal update to make visclaw work again, due to changes in clawutils/clawdata.py that broke it. 

I have suggestions on how to implement the control of attributes in the new Data and ClawData classes, but those are for the future.
