### PR TITLE
format -> file_format

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -209,7 +209,7 @@ class ClawPlotData(Data):
 
         if self.refresh_frames or (not framesoln_dict.has_key(key)):
             try:
-                framesoln = solution.Solution(frameno,path=outdir,format=self.format)
+                framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
             except:
                 print '*** Error reading frame in ClawPlotData.getframe'
                 raise


### PR DESCRIPTION
Avoid stomping on Python keyword 'format'.  This should be done more generally in VisClaw.
