### PR TITLE
Fix import from visclaw

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -235,9 +235,9 @@ class ClawPlotData(Data):
         """
 
         if format=='petsc':
-            format_module = __import__('petclaw.io.%s' % format, fromlist=['petclaw','io'])
+            format_module = __import__('clawpack.petclaw.io.%s' % format, fromlist=['petclaw','io'])
         else:
-            format_module = __import__('pyclaw.io.%s' % format, fromlist=['pyclaw','io'])
+            format_module = __import__('clawpack.pyclaw.io.%s' % format, fromlist=['pyclaw','io'])
         format_read_t = getattr(format_module, 'read_%s_t' % format)
         t,meqn,npatches,maux,num_dim = format_read_t(frameno,path=outdir)
         return t


### PR DESCRIPTION
Fix a bug in the gettime routine which attempts to import the pyclaw.io routine that reads in the fort.t file.  Only appears when using the html plotting option.
