### PR TITLE
Avoid using too much memory when plotting many frames non-interactively.

### DIFF
--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -1926,9 +1926,10 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     """
 
     import glob, sys, os
-    import numpy as np
     from clawpack.visclaw.data import ClawPlotData
     from clawpack.visclaw import frametools, gaugetools, plotpages
+
+    plotdata.save_frames = False
 
     datadir = os.getcwd()  # assume data files in this directory
 


### PR DESCRIPTION
Flush plotdata.framesoln_dict at the top of plotclaw_driver().
This avoids a buildup of memory consumption, resolving issue #27.
