### PR TITLE
Thousand frames

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1054,7 +1054,7 @@ def printframes(plotdata=None, verbose=True):
 
     import glob
     for file in glob.glob('fort.q*'):
-        frameno = int(file[7:10])
+        frameno = int(file[6:9])
         fortfile[frameno] = file
         for figno in fignos:
             pngfile[frameno,figno] = 'frame' + file[-4:] + 'fig%s.png' % figno
@@ -1311,14 +1311,14 @@ def only_most_recent(framenos,outdir='.',verbose=True):
 
     fortfile = {}
     for file in glob.glob('fort.q*'):
-        frameno = int(file[7:10])
+        frameno = int(file[6:9])
         fortfile[frameno] = file
 
     #DK: In PetClaw, we don't output fort.q* files.  Instead count the
     #claw.pkl* files.
     if len(fortfile) == 0:
         for file in glob.glob('claw.pkl*'):
-            frameno = int(file[9:12])
+            frameno = int(file[8:11])
             fortfile[frameno] = file
     
     if len(fortfile) == 0:


### PR DESCRIPTION
The selection of frame numbers based on file names has been using the wrong part of the file name.  This only causes problems when there are more than 999 frames.  This pull request fixes the issue so that frames numbered 1000 and higher are correctly detected.
