### PR TITLE
Don't swallow exceptions on file not found, unless in interactive mode.

### DIFF
--- a/src/python/visclaw/Iplotclaw.py
+++ b/src/python/visclaw/Iplotclaw.py
@@ -235,10 +235,13 @@ class Iplotclaw(cmd.Cmd):
         else:
             try:
                 newframeno = int(newframeno)
-                self.frameno = newframeno
-                self.current_data = frametools.plotframe(self.frameno, self.plotdata)
-            except:
+            except ValueError:
                 print '\n    *** Error: frameno must be an integer, n, or p'
+            self.frameno = newframeno
+            try:
+                self.current_data = frametools.plotframe(self.frameno, self.plotdata)
+            except IOError:
+                print "Swallowing IOError to avoid crashing in interactive mode."
                 #print '\n Requested frameno = %s  %s' %(newframeno,type(newframeno))
     def help_j(self):
         print 'j N: jump to frame N\n'

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -196,12 +196,7 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if self.refresh_frames or (not framesoln_dict.has_key(key)):
-            try:
-                framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
-            except:
-                print '*** Error reading frame in ClawPlotData.getframe'
-                raise
-                return
+            framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
             if not self.save_frames:
                 framesoln_dict.clear()
             framesoln_dict[key] = framesoln


### PR DESCRIPTION
When visclaw attempts to load a solution frame and the file is not found, it will crash and return a traceback -- unless it is in interactive mode, in which case it will warn the user that it is swallowing an IOError exception.

This will make it much easier to debug other issues affecting loading of a solution frame.  Currently, such debugging is difficult because the errors are swallowed.

Also: clean up a few issues found by pylint.
