### PR TITLE
Simple interactive plotting mode.

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -25,7 +25,7 @@ import clawpack.clawutil.clawdata as clawdata
 
 
 #==============================================================================
-def plotframe(frameno, plotdata, verbose=False):
+def plotframe(frameno, plotdata, verbose=False, simple=False):
 #==============================================================================
 
     """
@@ -37,6 +37,13 @@ def plotframe(frameno, plotdata, verbose=False):
     """
 
     if verbose:  print '    Plotting frame %s ... '  % frameno
+
+    if simple:
+        plotfun = plotdata.setplot
+        from clawpack.pyclaw import Solution
+        sol = Solution(frameno,path=plotdata.outdir,file_format=plotdata.format)
+        plotfun(sol)
+        return
 
     if plotdata.mode() == 'iplotclaw':
         pylab.ion()


### PR DESCRIPTION
This PR adds an option for "simple" interactive plotting with Iplotclaw.  I often find that I'd like to perform some post-processing and plotting that is difficult or impossible within visclaw's framework, but is easy to write with pure matplotlib and numpy.  But I would like to use visclaw's interactive plotting mode, too.

With this PR, I can define a simple plot function that operates on a Solution object, like:

```
def plotfun(sol):
    import matplotlib.pyplot as plt
    x = sol.state.grid.x.centers
    plt.plot(x,sol.q[0,:])
```

and then use it in interactive mode via

```
import plotfun
from clawpack.visclaw import Iplotclaw
ip = Iplotclaw.Iplotclaw(setplot=plotfun,outdir='./_output',simple=True)
ip.plotloop()
```

I simply pass my plotting function in place of setplot and use the keyword argument simple=True.  Overloading setplot here may be a bit hacky, and I'm not sure that everything works, though I have tested the basic functionality.
