### PR TITLE
Fixed temp files bug that made JSAnimation slow

### DIFF
--- a/src/python/visclaw/JSAnimation/html_writer.py
+++ b/src/python/visclaw/JSAnimation/html_writer.py
@@ -299,8 +299,8 @@ class HTMLWriter(FileMovieWriter):
                              dpi=self.dpi, **savefig_kwargs)
             f.reset()
             self._saved_frames.append(f.read().encode('base64'))
-        else:
-            return super(HTMLWriter, self).grab_frame(**savefig_kwargs)
+        #else:
+            #return super(HTMLWriter, self).grab_frame(**savefig_kwargs)
 
     def _run(self):
         # make a ducktyped subprocess standin


### PR DESCRIPTION
Fixed bug in htmlwriter.py from updated version of JSAnimation that produced a bunch of temp files and slowed down the speed at which JSAnimations were created.
