### PR TITLE
Fixed colorbars, which have not been appearing in 2d plots...

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -758,6 +758,11 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('patch_bgcolor','w')
             self.add_attribute('patchedges_show',0)
             self.add_attribute('patchedges_color','k')
+            self.add_attribute('add_colorbar',False)
+            self.add_attribute('colorbar_shrink',1.0)
+            self.add_attribute('colorbar_label',None)
+            self.add_attribute('colorbar_ticks', None)
+            self.add_attribute('colorbar_tick_labels',None)
             self.add_attribute('kwargs',{})
             amr_attributes = """celledges_show celledges_color patch_bgcolor
                      patchedges_show patchedges_color kwargs""".split()
@@ -769,18 +774,12 @@ class ClawPlotItem(clawdata.ClawData):
                 self.add_attribute('pcolor_cmap',colormaps.yellow_red_blue)
                 self.add_attribute('pcolor_cmin',None)
                 self.add_attribute('pcolor_cmax',None)
-                self.add_attribute('add_colorbar',True)
-                self.add_attribute('colorbar_shrink',1.0)
-                self.add_attribute('colorbar_label',None)
 
             elif plot_type == '2d_imshow':
                 from clawpack.visclaw import colormaps
                 self.add_attribute('imshow_cmap',colormaps.yellow_red_blue)
                 self.add_attribute('imshow_cmin',None)
                 self.add_attribute('imshow_cmax',None)
-                self.add_attribute('add_colorbar',True)
-                self.add_attribute('colorbar_shrink',1.0)
-                self.add_attribute('colorbar_label',None)
 
 
             elif plot_type in ['2d_contour', '2d_contourf']:
@@ -791,11 +790,6 @@ class ClawPlotItem(clawdata.ClawData):
                 self.add_attribute('contour_show',1)
                 self.add_attribute('contour_colors','k')
                 self.add_attribute('contour_cmap',None)
-                self.add_attribute('add_colorbar',False)
-                self.add_attribute('colorbar_shrink',1.0)
-                self.add_attribute('colorbar_label',None)
-                self.add_attribute('colorbar_ticks', None)
-                self.add_attribute('colorbar_tick_labels',None)
                 amr_attributes = """show colors cmap""".split()
                 for a in amr_attributes:
                     self.add_attribute('amr_contour_%s' % a, [])
@@ -813,9 +807,6 @@ class ClawPlotItem(clawdata.ClawData):
                 self.add_attribute('schlieren_cmap',colormaps.schlieren_grays)
                 self.add_attribute('schlieren_cmin',None)
                 self.add_attribute('schlieren_cmax',None)
-                self.add_attribute('add_colorbar',False)
-                self.add_attribute('colorbar_shrink',1.0)
-                self.add_attribute('colorbar_label',None)
 
             elif plot_type == '2d_patch':
                 self.add_attribute('max_density',None)

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -256,7 +256,7 @@ def plotframe(frameno, plotdata, verbose=False, simple=False, refresh=False):
                     print "*** use ClawPlotAxes.afteraxes "
                     print "*** or  ClawPlotItem.afterpatch instead"
                 try:
-                    if plotitem.add_colorbar:
+                    if plotitem.has_attribute('add_colorbar') and plotitem.add_colorbar:
                         pobj = plotitem._current_pobj # most recent plot object
                         cbar = pylab.colorbar(pobj, \
                                      shrink=plotitem.colorbar_shrink,\
@@ -267,6 +267,7 @@ def plotframe(frameno, plotdata, verbose=False, simple=False, refresh=False):
                         if plotitem.colorbar_label is not None:
                             cbar.set_label(plotitem.colorbar_label)
                 except:
+                    print "*** problem generating colorbar"
                     pass
 
 


### PR DESCRIPTION
New attributes colobar_label, colorbar_ticks, etc. were added but omitted from 2d_pcolor plot_type, for example.  Added them more generally.
Also modified frametools.py to check if attribute add_colorbar exists rather than throwing an exception that was being ignored.

Note that most gallery plots will change as a result.
