### PR TITLE
set Agg backend in plotclaw.py 

### DIFF
--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -16,6 +16,8 @@ From most Clawpack applications directories the command
 will call the plotclaw function from this module.
 
 """
+import matplotlib
+matplotlib.use('Agg') 
 
 import sys, os
 import pylab


### PR DESCRIPTION
for some systems where it complains about DISPLAY not being set when running 'make plots'.
