### PR TITLE
Add level as attribute of current_data

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -202,6 +202,7 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                     patch = state.patch
 
                     current_data.add_attribute('patch',patch)
+                    current_data.add_attribute("level",1)
                     current_data.add_attribute('q',state.q)
                     current_data.add_attribute('var',None)
                     current_data.add_attribute('aux',state.aux)


### PR DESCRIPTION
Not having level already added to current_data seemed to be breaking
things in 1d.  Line 421 caused this:

```
current_data.level = getattr(patch,'level',1)
```

Fix for #104.
