### PR TITLE
do not try to read aux files.

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -193,7 +193,8 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if refresh or (not framesoln_dict.has_key(key)):
-            framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
+            framesoln = solution.Solution(frameno,path=outdir, \
+                        file_format=self.format,read_aux=False)
             if not self.save_frames:
                 framesoln_dict.clear()
             framesoln_dict[key] = framesoln


### PR DESCRIPTION
Default in pyclaw/solution.py apparently change with read_aux=True being the default, causing error messages to print from visclaw for problems with aux arrays.

Avoids output like this...

```
Now making png files for all figures...
2014-06-11 16:49:21,204 INFO CLAW: Unable to open auxillary file /Users/rjl/git/clawpack/amrclaw/examples/advection_2d_annulus/_output/fort.a0000 or /Users/rjl/git/clawpack/amrclaw/examples/advection_2d_annulus/_output/fort.a0000
    Reading  Frame 0 at t = 0  from outdir = /Users/rjl/git/clawpack/amrclaw/examples/advection_2d_annulus/_output
Frame 0 at time t = 0.0
```
