### PR TITLE
Time checking

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -184,10 +184,10 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
 
             for i, framesoln in enumerate(framesolns):
 
-                if framesoln.t != t:
+                if abs(framesoln.t - t) > 1e-12:
                     print '*** Warning: t values do not agree for frame ',frameno
-                    print '*** t = %g for outdir = %s' % (t,plotdata.outdir)
-                    print '*** t = %g for outdir = %s' % (framesoln.t,plotdata._outdirs[i])
+                    print '*** t = %22.15e for outdir = %s' % (t,plotdata.outdir)
+                    print '*** t = %22.15e for outdir = %s' % (framesoln.t,plotdata._outdirs[i])
 
                 current_data.add_attribute('framesoln',framesoln)
 


### PR DESCRIPTION
Don't require exact agreement of times when making plots comparing two sets of results.

Maybe should add a tolerance rather than hardwiring 1e-12, but this is just a warning in any case.
