### PR TITLE
script to fix JSAnimation movies when spaces appear incorrectly in strings

### DIFF
--- a/src/python/visclaw/JSAnimation/fix_jsmovies.py
+++ b/src/python/visclaw/JSAnimation/fix_jsmovies.py
@@ -1,0 +1,49 @@
+
+"""
+JSAnimation sometimes puts a space between anim and the hash code in lines such as 
+    onclick="anim6c16c71bbda280b...
+The webpage then shows a broken link.
+
+fix_file function below fixes a single file.
+fix_movie fixes a file produced by Clawpack plotting routines.
+fix_movies fixes all movie files in a specified plotdir.
+
+Default if run from command line is to fix all movies in _plots.
+Can specify plotdir and optionally figno for movie on the command line.
+
+It would be better to figure out the bug in JSAnimation.html_writer.
+"""
+
+import os, glob
+
+def fix_file(fname, verbose=True):
+    f = open(fname,'r')
+    html = f.read()
+    f.close()
+
+    html = html.replace('anim ','anim')
+
+    f = open(fname,'w')
+    f.write(html)
+    f.close()
+    if verbose:
+        print "Fixed file ",fname
+
+def fix_movie(plotdir, figno):
+    fname = os.path.join(plotdir, 'movieframe_allframesfig%s.html' % figno)
+    fix_file(fname)
+    
+def fix_movies(plotdir='_plots'):
+    pattern = r'movieframe_allframesfig*.html'
+    files = glob.glob(os.path.join(plotdir, pattern))
+    for fname in files:
+        fix_file(fname)
+    
+if __name__=="__main__":
+    import sys
+    args = sys.argv[1:]   # any command line arguments
+    if len(args) < 2:
+        fix_movies(*args)
+    else:
+        fix_movie(*args)
+


### PR DESCRIPTION
Every now and then a JSAnimation movie in the _plots directory doesn't work properly because spurious spaces appear in the file names, e.g.

```
onclick="anim 6c16c71bbda280b...
```
which should not have a space after `anim`. 

@jakevdp looked at this at one point and wasn't sure why.  This is just a script to fix such files.   Perhaps call this automatically when making animations?