### PR TITLE
Fix format handling in `gettime` to be more general

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -220,15 +220,19 @@ class ClawPlotData(clawdata.ClawData):
         this routine returns None if that's the case.
         """
         if format == 'petsc':
-            from clawpack.petclaw import io
-            read_t = io.petsc.read_t
-        elif format == 'ascii': 
-            from clawpack.pyclaw import io
-            read_t = io.ascii.read_t
+            import clawpack.petclaw.io
+            read_t = clawpack.petclaw.io.petsc.read_t
 
+        else:
+            module = __import__("clawpack.pyclaw.io.%s" % format, 
+                                                fromlist=['clawpack.pyclaw.io'])
+            if "read_t" in dir(module):
+                read_t = module.read_t
+            else:
+                return None
 
-        t, meqn, npatches, maux, num_dim = read_t(frameno, path=outdir)
-        return t
+        header_info = read_t(frameno, path=outdir)
+        return header_info[0]
 
     def clearfigures(self):
         """

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -81,7 +81,7 @@ class ClawPlotData(clawdata.ClawData):
         self.add_attribute('setplot',False)            # Execute setplot.py in plot routine
 
         self.add_attribute('mapc2p',None)              # function to map computational
-	                                    # points to physical
+                                        # points to physical
 
 
         self.add_attribute('beforeframe',None)         # function called before all plots 
@@ -213,34 +213,35 @@ class ClawPlotData(clawdata.ClawData):
 
         return framesoln
         
-    def gettime(self,frameno,outdir='./',format='ascii'):
+    def gettime(self, frameno, outdir='./', format='ascii'):
         r"""Fetch time from solution corresponding to frame number in outdir
         
-        This method only works for ascii and petsc formatted files
+        Some of the file formats do not have the appropriate function and so
+        this routine returns None if that's the case.
         """
-        if format=='petsc':
+        if format == 'petsc':
             from clawpack.petclaw import io
             read_t = io.petsc.read_t
-        elif format=='ascii': 
+        elif format == 'ascii': 
             from clawpack.pyclaw import io
             read_t = io.ascii.read_t
 
 
-        t,meqn,npatches,maux,num_dim = read_t(frameno,path=outdir)
+        t, meqn, npatches, maux, num_dim = read_t(frameno, path=outdir)
         return t
 
     def clearfigures(self):
         """
         Clear all plot parameters specifying figures, axes, items.
-	    Does not clear the frames of solution data already read in.
-	    For that use clearframes.
+        Does not clear the frames of solution data already read in.
+        For that use clearframes.
         """
 
-	self.plotfigure_dict.clear()
-	self._fignames = []
-	self._fignos = []
-	self._next_FIG = 1000
-	self._otherfignames = []
+        self.plotfigure_dict.clear()
+        self._fignames = []
+        self._fignos = []
+        self._next_FIG = 1000
+        self._otherfignames = []
 
 
     def clearframes(self, framenos='all'):
@@ -628,9 +629,9 @@ class ClawPlotFigure(clawdata.ClawData):
         """
         Create a new axes that will be plotted in this figure.
         If type='each_frame' it is an axes that will be plotted 
-	for each time frame.
+        for each time frame.
         If type='multi_frame' it is an axes that will be plotted based on
-	all the frames, such as x-t plots or time series. (Not yet implemented)
+        all the frames, such as x-t plots or time series. (Not yet implemented)
         If type='empty' it is created without doing any plots using the
         pyclaw tools.  Presumably the user will create a plot within an
         afteraxes command, for example.
@@ -771,8 +772,8 @@ class ClawPlotItem(clawdata.ClawData):
                                         # if _plotdata.mapc2p is not None.
 
         self.add_attribute('mapc2p',None)              # function to map computational
-	                                # points to physical (over-rides
-	                                # plotdata.mapc2p if set for item
+                                    # points to physical (over-rides
+                                    # plotdata.mapc2p if set for item
 
 
         self.add_attribute('afterpatch',None)           # function called after each patch is

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -1750,7 +1750,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
     # Only grab times by loading in time
     for frameno in framenos:
-        frametimes[frameno] = plotdata.gettime(frameno, plotdata.outdir, format=format)
+        frametimes[frameno] = plotdata.gettime(frameno, plotdata.outdir, format=plotdata.format)
     # for frameno in framenos:
     #     frametimes[frameno] = plotdata.getframe(frameno, plotdata.outdir).t
 


### PR DESCRIPTION
Previously if `gettime` was ever called and the format requested was not `petsc` or `ascii` the code would raise an exception.  Now this checks to see if the file format requested's module contains the function `read_t` and uses that.  Since this routine only cares about time the inconsistent number of variable returned by some of the formats (`binary` in this case) is handled gracefully.  If not `read_t` exists then `None` is returned.

Other fixes:
 - Corrected tabs to spaces and some other spacing issues
 - Addressed the file format specification mentioned in #140 as this bug only appears when file formats are properly handled.