### PR TITLE
import IPython_display properly -- 

### DIFF
--- a/src/python/visclaw/JSAnimation/JSAnimation_frametools.py
+++ b/src/python/visclaw/JSAnimation/JSAnimation_frametools.py
@@ -8,6 +8,8 @@ import glob
 from matplotlib import image, animation
 from matplotlib import pyplot as plt
 
+from clawpack.visclaw.JSAnimation import IPython_display
+
 def make_plotdir(plotdir='_plots', clobber=True):
     """
     Utility function to create a directory for storing a sequence of plot


### PR DESCRIPTION
needs to be imported in module for notebooks to display animations. Import from clawpack.visclaw rather than assuming JSAnimation installed.

Fixing a bug I introduced in #141 