### PR TITLE
[WIP] Use output controller format rather than data object's

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -217,7 +217,8 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if refresh or (not framesoln_dict.has_key(key)):
-            framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
+            framesoln = solution.Solution(frameno, path=outdir, 
+                                 file_format=self.output_controller.file_format)
             if not self.save_frames:
                 framesoln_dict.clear()
             framesoln_dict[key] = framesoln


### PR DESCRIPTION
I again ran into a case where the `plotdata` object's `format` was overridden somewhere and reset to ascii.  Using the `output_controller` instead and setting it's `file_format` value seems to be safer but this is really a non-intuitive interface since there already exists a `format` attribute in the data object.  Suggestions?