### PR TITLE
Leave KML figures in plots direcotry, not just in KMZ file

### DIFF
--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -791,7 +791,7 @@ def plotclaw2kml(plotdata):
 
                 os.chdir(fig_dir)
                 pngfile = os.path.join("..","%s.png"% fname_str)
-                shutil.move(pngfile,".")
+                shutil.copy(pngfile,".")
                 im = plt.imread("%s.png" % fname_str)
                 sx = im.shape[1]   # reversed?
                 sy = im.shape[0]


### PR DESCRIPTION
This prevents the animation creation step from breaking if it doesn't find KML figures. 

In fact, the KML figures should probably not be in the PlotIndex, or animated, so this fix is temporary.   But it looks like skipping KML figures in the plotclaw2html or movie code is more involved than I thought.

This is a non-issue when separate setplot files are created for non-kml and kml files.  In this case, all figures will either be KML or non-KML, and so the animation step is happy in either case.