### PR TITLE
Added amr_data_show attribute to suppress certain amr levels

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -833,8 +833,8 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('colorbar_ticks', None)
             self.add_attribute('colorbar_tick_labels',None)
             self.add_attribute('kwargs',{})
-            amr_attributes = """celledges_show celledges_color patch_bgcolor
-                     patchedges_show patchedges_color kwargs""".split()
+            amr_attributes = """celledges_show celledges_color data_show 
+              patch_bgcolor patchedges_show patchedges_color kwargs""".split()
             for a in amr_attributes:
                 self.add_attribute('amr_%s' % a, [])
 

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -262,11 +262,11 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         num_dim = plotitem.num_dim
 
                         # option to suppress printing some levels:
-                        try:
-                            pp['amr_data_show'] = plotitem.amr_data_show
-                            i = min(len(pp['amr_data_show']), state.level) - 1
-                            show_this_level = pp['amr_data_show'][i]
-                        except:
+                        amr_data_show = plotitem.amr_data_show
+                        if len(amr_data_show) > 0:
+                            j = min(len(amr_data_show), patch.level) - 1
+                            show_this_level = amr_data_show[j]
+                        else:
                             show_this_level = True
 
                         if plotitem._show and show_this_level:


### PR DESCRIPTION
For backwards compatibility, included conditional that should default to showing all levels if amr_data_show is not set.