### PR TITLE
Matplotlib Parallel Plotting Capabilities

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -146,6 +146,14 @@ class ClawPlotData(clawdata.ClawData):
         self.add_attribute('gauges_fignos',None)
         self.add_attribute('gauges_fignames',None)
 
+        # Parallel capabilities
+        # Run multiple processess dividing up the frames that need to be plotted
+        self.add_attribute('parallel', True)
+        # Default to OMP_NUM_THREADS available if defined
+        self.add_attribute('num_procs', None)
+        self.add_attribute('proc_frames', None)
+
+
         self._next_FIG = 1000
         self._fignames = []
         self._fignos = []

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -152,7 +152,7 @@ class ClawPlotData(clawdata.ClawData):
         # Default to OMP_NUM_THREADS available if defined
         self.add_attribute('num_procs', None)
         self.add_attribute('proc_frames', None)
-        self.add_attribute('_subprocess', False)
+        self.add_attribute('_parallel_todo', None)
 
 
         self._next_FIG = 1000

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -152,6 +152,7 @@ class ClawPlotData(clawdata.ClawData):
         # Default to OMP_NUM_THREADS available if defined
         self.add_attribute('num_procs', None)
         self.add_attribute('proc_frames', None)
+        self.add_attribute('_subprocess', False)
 
 
         self._next_FIG = 1000

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -57,7 +57,10 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
     frametools.call_setplot(plotdata.setplot, plotdata)
 
 
-    if plotdata.parallel:
+    if plotdata.num_procs is None:
+        plotdata.num_procs = int(os.environ.get("OMP_NUM_THREADS", 1))
+
+    if plotdata.parallel and plotdata.num_procs != 1:
 
         # If this is the original call then we need to split up the work and 
         # call this function again

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -83,7 +83,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
                 frames[n%num_procs].append(frame)
 
             # Create subprocesses to work on each
-            plotclaw_cmd = "python $CLAW/visclaw/src/python/visclaw/plotclaw.py"
+            plotclaw_cmd = "python %s" % __file__
             process_queue = []
             for n in xrange(num_procs):
                 plot_cmd = "%s %s %s %s" % (plotclaw_cmd, 
@@ -139,7 +139,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
 
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     """
     If executed at command line prompt, simply call the function, with
     any arguments passed in.

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -60,6 +60,11 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
         # If this is the original call then we need to split up the work and 
         # call this function again
 
+        # First set up plotdir:
+
+        plotdata._parallel_todo = 'initialize'
+        plotpages.plotclaw_driver(plotdata, verbose=False, format=format)
+
         if frames is None:
             if plotdata.num_procs is None:
                 plotdata.num_procs = os.environ.get("OMP_NUM_THREADS", 1)
@@ -101,17 +106,18 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
 
             # After all frames have been plotted via recursive calls,
             # make index and gauge plots only:
-            plotdata._subprocess = False
+            plotdata._parallel_todo = 'finalize'
             plotpages.plotclaw_driver(plotdata, verbose=False, format=format)
 
         else:
             # make frame plots only:
-            plotdata._subprocess = True 
+            plotdata._parallel_todo = 'frames'
             plotdata.print_framenos = frames
             plotpages.plotclaw_driver(plotdata, verbose=False, format=format)
 
     else:
         # not in parallel:
+        plotdata._parallel_todo = None
         plotpages.plotclaw_driver(plotdata, verbose=False, format=format)
 
 

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -32,7 +32,7 @@ if sys.platform in ['win32','cygwin']:
 
 
 def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
-             format='ascii', msgfile='', frames=None):
+             format='ascii', msgfile='', frames=None, verbose=False):
     """
     Create html and/or latex versions of plots.
 
@@ -52,6 +52,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
     plotdata.format = format
     plotdata.msgfile = msgfile
 
+
     frametools.call_setplot(plotdata.setplot, plotdata)
 
 
@@ -67,7 +68,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
 
         if frames is None:
             if plotdata.num_procs is None:
-                plotdata.num_procs = os.environ.get("OMP_NUM_THREADS", 1)
+                plotdata.num_procs = int(os.environ.get("OMP_NUM_THREADS", 1))
 
 
             frames = [[] for n in xrange(plotdata.num_procs)]
@@ -102,7 +103,8 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
                     for process in process_queue:
                         if process.poll() is not None:
                             process_queue.remove(process)
-                    print "Number of processes currently:",len(process_queue)
+                    if verbose:
+                        print "Number of processes currently:",len(process_queue)
 
             # After all frames have been plotted via recursive calls,
             # make index and gauge plots only:

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2705,7 +2705,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
     plotdata._mode = 'printframes'
 
-    plotdata = frametools.call_setplot(plotdata.setplot, plotdata)
+    # plotdata = frametools.call_setplot(plotdata.setplot, plotdata)
 
     try:
         plotdata.rundir = os.path.abspath(plotdata.rundir)
@@ -2836,7 +2836,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     # Discard frames that are not from latest run, based on
     # file modification time:
     framenos = frametools.only_most_recent(framenos, plotdata.outdir)
-
+    
     numframes = len(framenos)
 
     print "Will plot %i frames numbered:" % numframes, framenos

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2691,7 +2691,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     from clawpack.visclaw.data import ClawPlotData
     from clawpack.visclaw import frametools, gaugetools, plotpages
 
-    if plotdata._subprocess:
+    if plotdata._parallel_todo == 'frames':
         # all we need to do is make png's for some frames in this case:
         for frameno in plotdata.print_framenos:
             frametools.plotframe(frameno, plotdata, verbose)
@@ -2799,16 +2799,21 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
     framefiles = glob.glob(os.path.join(plotdir,'frame*.png')) + \
                     glob.glob(os.path.join(plotdir,'frame*.html'))
-    if overwrite:
-        # remove any old versions:
-        for file in framefiles:
-            os.remove(file)
-    else:
-        if len(framefiles) > 1:
-            print "*** Remove frame*.png and frame*.html and try again,"
-            print "  or use overwrite=True in call to printframes"
-            return plotdata
 
+    if (not plotdata.parallel) or (plotdata._parallel_todo=='initialize'):
+        if overwrite:
+            # remove any old versions:
+            for file in framefiles:
+                os.remove(file)
+        else:
+            if len(framefiles) > 1:
+                print "*** Remove frame*.png and frame*.html and try again,"
+                print "  or use overwrite=True in call to printframes"
+                return plotdata
+
+    if plotdata._parallel_todo=='initialize':
+        os.chdir(rundir)
+        return plotdata
 
     try:
         os.chdir(outdir)
@@ -2916,7 +2921,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
         if not plotdata.parallel:
             # don't create the png for frames when run in parallel
-            # (unless plotdata._subprocess == True, checked earlier)
+            # (unless plotdata._parallell_todo=='frames', handled earlier)
             for frameno in framenos:
                 frametools.plotframe(frameno, plotdata, verbose)
                 print 'Frame %i at time t = %s' % (frameno, frametimes[frameno])
@@ -2968,9 +2973,6 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
         for figno in fignos_each_frame:
             fname = '*fig' + str(figno) + '.png'
             filenames=sorted(glob.glob(fname))
-            print '+++ filenames: ',filenames
-            # dies here unexpected in parallel
-            #import pdb; pdb.set_trace()
             fig = plt.figure()
             im = plt.imshow(Image.imread(filenames[0]))
             def init():


### PR DESCRIPTION
This PR should act as a prototype for using multiple processes for plotting in VisClaw.  The basic methodology goes like this:

1. First call to `plotclaw.py` from the command line (or elsewhere) checks to see if the `plotdata` object's `plotdata.parallel` is set to `True`.  If this is the case and the additional argument `frames` to `plotclaw.plotclaw` is `None` then the routine assumes that this is the first call to the plot function and plays the role dividing up the frames among all the requested `plotdata.num_procs`.
1. A new `subprocess` is spawned for each process but with an additional argument to `plotclaw.py` that includes the `frames` it should plot.
1. The originating process waits around while the other processes plot the data.

This is admittedly very "hacky" but due to limitations in the `multiprocessing` module due to pickling this was the one way I could figure out how to do this with a minimal amount of intrusiveness into VisClaw.

