### PR TITLE
Googleearth visualization of overland flooding events

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -94,6 +94,7 @@ class ClawPlotData(clawdata.ClawData):
         self.add_attribute('kml_name',"GeoClaw")
         self.add_attribute('kml_starttime',None)
         self.add_attribute('kml_tz_offset',None)
+        self.add_attribute('kml_map_topo_to_latlong',None)
 
         self.add_attribute('gif_movie',False)          # make animated gif movie of frames
 

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -641,7 +641,7 @@ class ClawPlotFigure(clawdata.ClawData):
         self.add_attribute('kml_dpi',200)
         self.add_attribute('kml_xlimits',None)
         self.add_attribute('kml_ylimits',None)
-        self.add_attribute('kml_use_figure_limits',None)
+        self.add_attribute('kml_use_figure_limits',True)
         self.add_attribute('kml_tile_images',False)
         self.add_attribute('kml_colorbar',None)
         self.add_attribute('kml_use_for_initial_view',False)

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -641,6 +641,7 @@ class ClawPlotFigure(clawdata.ClawData):
         self.add_attribute('kml_dpi',200)
         self.add_attribute('kml_xlimits',None)
         self.add_attribute('kml_ylimits',None)
+        self.add_attribute('kml_use_figure_limits',None)
         self.add_attribute('kml_tile_images',False)
         self.add_attribute('kml_colorbar',None)
         self.add_attribute('kml_use_for_initial_view',False)
@@ -842,7 +843,7 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('colorbar_ticks', None)
             self.add_attribute('colorbar_tick_labels',None)
             self.add_attribute('kwargs',{})
-            amr_attributes = """celledges_show celledges_color data_show 
+            amr_attributes = """celledges_show celledges_color data_show
               patch_bgcolor patchedges_show patchedges_color kwargs""".split()
             for a in amr_attributes:
                 self.add_attribute('amr_%s' % a, [])

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -202,7 +202,7 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         current_data.add_attribute('yupper',patch.dimensions[1].upper)
                         current_data.add_attribute('y',patch.grid.p_centers[1])
                         current_data.add_attribute('dy',patch.delta[1])
-            
+
                     if plotfigure.use_for_kml:
 
                         # -------------------------------------------------------------
@@ -330,7 +330,7 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                 plt.axis('image')
 
             # set axes limits:
-            if plotfigure.use_for_kml:
+            if (plotfigure.use_for_kml and plotfigure.kml_use_figure_limits):
                 if (plotfigure.kml_xlimits is not None) & (type(plotfigure.kml_xlimits) is not str):
                     try:
                         plt.xlim(plotfigure.kml_xlimits[0], plotfigure.kml_xlimits[1])
@@ -348,7 +348,6 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         print "*** KML error : Set plotfigure.kml_ylimits"
                         print " "
                         return
-
             else:
                 if (plotaxes.xlimits is not None) & (type(plotaxes.xlimits) is not str):
                     try:

--- a/src/python/visclaw/geoplot.py
+++ b/src/python/visclaw/geoplot.py
@@ -59,6 +59,12 @@ googleearth_transparent = colormaps.make_colormap({-1.0:light_green_a,
                                                    0.0:transparent,
                                                    1.0:red_a})
 
+# Start transparency at 0.2
+googleearth_flooding = colormaps.make_colormap({ -1:transparent,
+                                                 -0.2:light_blue,
+                                                 1.0:dark_blue})
+
+
 tsunami_colormap = colormaps.make_colormap({-TSUNAMI_MAX_AMPLITUDE:blue,
                                             0.0:blue_green,
                                             TSUNAMI_MAX_AMPLITUDE:red})
@@ -111,7 +117,7 @@ land_colormap = colormaps.make_colormap({ 0:[0.95,0.9,0.7],
 
 colormaps_list = {"tsunami":tsunami_colormap,"land1":land1_colormap,
              "land2":land2_colormap,"water_land":water_land_colormap,
-             "bathy1":bathy1_colormap,"bathy2":bathy2_colormap}
+                  "bathy1":bathy1_colormap,"bathy2":bathy2_colormap}
 
 def plot_colormaps():
     r"""Plots all colormaps avaiable or the ones specified"""

--- a/src/python/visclaw/geoplot.py
+++ b/src/python/visclaw/geoplot.py
@@ -195,6 +195,13 @@ def depth(current_data):
    q = current_data.q
    h = q[0,:,:]
    depth = numpy.ma.masked_where(h<=drytol, h)
+   try:
+       # Use mask covering coarse regions if it's set:
+       m = current_data.mask_coarse
+       depth = numpy.ma.masked_where(m, depth)
+   except:
+       pass
+
    return depth
 
 

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -773,7 +773,10 @@ def plotclaw2kml(plotdata):
 
                 # PNG file gets moved into subdirectory and will eventually be
                 # zipped into KMZ file.
-                shutil.move(os.path.join("..","%s.png" % fname_str),fname_str)
+                if plotdata.html:
+                    shutil.copy(os.path.join("..","%s.png" % fname_str),fname_str)
+                else:
+                    shutil.move(os.path.join("..","%s.png" % fname_str),fname_str)
 
                 # The actual file to be written <framename>/doc.kml
                 docfile = os.path.join(fname_str,'doc.kml')

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -773,7 +773,7 @@ def plotclaw2kml(plotdata):
 
                 # PNG file gets moved into subdirectory and will eventually be
                 # zipped into KMZ file.
-                shutil.move(os.path.join("..","%s.png" % fname_str),fname_str)
+                shutil.copy(os.path.join("..","%s.png" % fname_str),fname_str)
 
                 # The actual file to be written <framename>/doc.kml
                 docfile = os.path.join(fname_str,'doc.kml')
@@ -2692,7 +2692,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     from clawpack.visclaw import frametools, gaugetools, plotpages
 
     # doing plots in parallel?
-    _parallel = plotdata.parallel and (plotdata.num_procs > 1) 
+    _parallel = plotdata.parallel and (plotdata.num_procs > 1)
 
     if plotdata._parallel_todo == 'frames':
         # all we need to do is make png's for some frames in this case:
@@ -2851,7 +2851,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     # Discard frames that are not from latest run, based on
     # file modification time:
     framenos = frametools.only_most_recent(framenos, plotdata.outdir)
-    
+
     numframes = len(framenos)
 
     print "Will plot %i frames numbered:" % numframes, framenos
@@ -2972,7 +2972,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
 
         # Create Animations
-        
+
         for figno in fignos_each_frame:
             fname = '*fig' + str(figno) + '.png'
             filenames=sorted(glob.glob(fname))

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -996,6 +996,8 @@ def plotclaw2kml(plotdata):
         for gnum,gauge in enumerate(gauges):
             t1,t2 = gauge[3:5]
             x1,y1 = gauge[1:3]
+            if plotdata.kml_map_topo_to_latlong is not None:
+                x1,y1 = plotdata.kml_map_topo_to_latlong(x1,y1)
             gaugeno = int(gauge[0])
 
             # Get proper coordinates, otherwise placemark doesn't show up.
@@ -1009,11 +1011,11 @@ def plotclaw2kml(plotdata):
             print "Gauge %i: %10.6f  %10.6f  \n" % (gaugeno,x1,y1) \
                 + "  t1 = %10.1f,  t2 = %10.1f" % (t1,t2)
 
-            # PNG file associated with this gauge
-            figname = 'not found'
-            for k in gauge_pngfile.keys():
-                if k[0] == gaugeno:
-                    figname = gauge_pngfile[k]
+            # plotdata.gauges_fignos
+            # Not clear how to get the figure number for each gauge.   Assume that
+            # there is only one figure number for all gauges
+            figno = plotdata.gauges_fignos[0]
+            figname = gauge_pngfile[gaugeno,figno]
 
             elev = 0
             coords = "%10.4f %10.4f %10.4f" % (longitude,y1,elev)
@@ -1097,10 +1099,16 @@ def plotclaw2kml(plotdata):
         lower = np.fromstring(c.strip(),sep=' ')
         c = f.readline()
         upper = np.fromstring(c.strip(),sep=' ')
-        x1 = lower[0]
-        x2 = upper[0]
-        y1 = lower[1]
-        y2 = upper[1]
+        if plotdata.kml_map_topo_to_latlong is not None:
+            x1,y1 = plotdata.kml_map_topo_to_latlong(lower[0],lower[1])
+            x2,y2 = plotdata.kml_map_topo_to_latlong(upper[0],upper[1])
+        else:
+            x1 = lower[0]
+            x2 = upper[0]
+            y1 = lower[1]
+            y2 = upper[1]
+
+
         bcomp_domain = \
                        "<style media=\"screen\" type=\"text/css\">" \
                        "pre {font-weight:bold;font-style:12pt}" + \
@@ -1468,6 +1476,9 @@ def plotclaw2kml(plotdata):
                 ylower = patch.dimensions[1].lower
                 yupper = patch.dimensions[1].upper
                 level = patch.level
+                if plotdata.kml_map_topo_to_latlong is not None:
+                    xlower,ylower = plotdata.kml_map_topo_to_latlong(xlower,ylower)
+                    xupper,yupper = plotdata.kml_map_topo_to_latlong(xupper,yupper)
 
                 # maxlevel_real should start at 0 so it can be used for indexing
                 maxlevel_real = max(level,maxlevel_real)
@@ -2671,7 +2682,7 @@ def redirect_stdouts(f):
     return wrapper
 
 #============================================
-@redirect_stdouts
+#@redirect_stdouts
 def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 #============================================
     """

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -773,7 +773,7 @@ def plotclaw2kml(plotdata):
 
                 # PNG file gets moved into subdirectory and will eventually be
                 # zipped into KMZ file.
-                shutil.copy(os.path.join("..","%s.png" % fname_str),fname_str)
+                shutil.move(os.path.join("..","%s.png" % fname_str),fname_str)
 
                 # The actual file to be written <framename>/doc.kml
                 docfile = os.path.join(fname_str,'doc.kml')
@@ -2682,7 +2682,7 @@ def redirect_stdouts(f):
     return wrapper
 
 #============================================
-#@redirect_stdouts
+@redirect_stdouts
 def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 #============================================
     """


### PR DESCRIPTION
Most changes are related to doing visualizations in Google Earth of over-land flooding events.  

* Added flooding colormap to geoplot.py (the visclaw version;  why is there also a geoclaw version?)
* added attribute to `plotdata.kml_map_topo_to_latlong` that maps computational coordinates to lat/long coordinates.    The main use is for mapping topo data provided in Cartesian coordinates to Latlong coordinates needed by Google Earth.

Other changes : 
* Updated the KML plotting to reflect current changes in how gauges are handled.  
* Minor change to how PNG files created for KML are stored;  if HTML=True, these files are saved in _plots directory, in addition to being archived in KMZ file.



