### PR TITLE
data.py should import GaugeSolution from PyClaw

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -310,7 +310,7 @@ class ClawPlotData(clawdata.ClawData):
             try:        
                 # Import necessary gauge description classes
                 import clawpack.amrclaw.data
-                import clawpack.amrclaw.gauges as gauges
+                import clawpack.pyclaw.gauges as gauges
 
                 # Read in gauge specification
                 gauge_data = clawpack.amrclaw.data.GaugeData()

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -308,17 +308,12 @@ class ClawPlotData(clawdata.ClawData):
         if self.refresh_gauges or (not self.gaugesoln_dict.has_key(key)):
     
             try:        
-                # Import necessary gauge description classes
-                import clawpack.amrclaw.data
+
+                # Read gauge solution:
                 import clawpack.pyclaw.gauges as gauges
 
-                # Read in gauge specification
-                gauge_data = clawpack.amrclaw.data.GaugeData()
-                gauge_data.read(outdir)
-
                 self.gaugesoln_dict[key] = gauges.GaugeSolution(
-                                                              gauge_id=gauge_id,
-                                                              path=outdir)
+                                           gauge_id=gauge_id, path=outdir)
 
                 if verbose:
                     print "Read in gauge %s." % gauge_id


### PR DESCRIPTION
@mandli: can you check this is correct?

It was still working on my computer because `gauges.pyc` was still in my `amrclaw/src/python/amrclaw` directory but the `gauges.py` file was moved to `pyclaw` in the process of updating the gauge routines, I think.
