### PR TITLE
Matlab : Fix use of 'break' when return should have been used

### DIFF
--- a/src/matlab/plotclaw1.m
+++ b/src/matlab/plotclaw1.m
@@ -77,7 +77,7 @@ Frame = -1;  % initialize frame counter
 
 if ~exist('MaxFrames')
   disp('MaxFrames parameter not set... you may need to execute setplot1')
-  break
+  return
 end
 
 set_value('frameinc','plot_interval',1);

--- a/src/matlab/plotclaw2.m
+++ b/src/matlab/plotclaw2.m
@@ -73,8 +73,8 @@ end
 
 if ~exist('MaxFrames')
    disp('MaxFrames parameter not set... you may need to execute setplot2')
-   break
-   end
+   return
+end
 
 set_value('frameinc','plot_interval',1);
 set_value('outputdir','OutputDir','./');

--- a/src/matlab/plotclaw3.m
+++ b/src/matlab/plotclaw3.m
@@ -69,7 +69,7 @@ if strcmp(whichfile,'')
 
 if ~exist('MaxFrames')
   disp('MaxFrames parameter not set... you may need to execute setplot3')
-  break;
+  return
 end
 
 set_value('frameinc','plot_interval',1);

--- a/src/matlab/queryframe.m
+++ b/src/matlab/queryframe.m
@@ -16,7 +16,7 @@ if exist('NoQuery')
     pause(1)
     Frame = Frame + frameinc;
     if Frame > MaxFrames
-      break;   % break out of plotclawN after last frame
+      return  % break out of plotclawN after last frame
     end
     return
   end
@@ -139,7 +139,7 @@ end % while strcmp
 
 if strcmp(inp,'q')
   % quit now
-  break
+  return
 end
 
 

--- a/src/matlab/setopengl.m
+++ b/src/matlab/setopengl.m
@@ -22,9 +22,9 @@ found_opengl = 0;
 for i = 1:length(rset),
   if (strcmp(lower(rset(i)),'opengl'))
     found_opengl = 1;
-    break;
-  end;
-end;
+    break
+  end
+end
 
 if (~found_opengl)
   disp('*** Warning : The OpenGL renderer is not available on your system.');


### PR DESCRIPTION
Minor change to compatibility with latest release of Matlab (15b)