### PR TITLE
Python3-compatible version of html_writer

### DIFF
--- a/src/python/visclaw/JSAnimation/html_writer.py
+++ b/src/python/visclaw/JSAnimation/html_writer.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 import os
 import warnings
 import random
-import cStringIO
+from io import StringIO, BytesIO
 from matplotlib.animation import writers, FileMovieWriter
 import random
 from six.moves import range
-
+import base64
 
 ICON_DIR = os.path.join(os.path.dirname(__file__), 'icons')
 
@@ -25,7 +25,7 @@ class _Icons(object):
     def _load_base64(self, filename):
         data = open(os.path.join(self.icon_dir, filename), 'rb').read()
         return 'data:image/{0};base64,{1}'.format(self.extension,
-                                                  data.encode('base64'))
+                                        base64.b64encode(data))
 
 PREV_INCLUDE = """
 {add_html}
@@ -244,7 +244,7 @@ def _embedded_frames(frame_list, frame_format):
     embedded = "\n"
     for i, frame_data in enumerate(frame_list):
         embedded += template.format(i, frame_format,
-                                    frame_data.replace('\n', '\\\n'))
+                                    frame_data.replace(b'\n', b'\\\n'))
     return embedded
 
 
@@ -307,11 +307,12 @@ class HTMLWriter(FileMovieWriter):
     def grab_frame(self, **savefig_kwargs):
         if self.embed_frames:
             suffix = '.' + self.frame_format
-            f = cStringIO.StringIO()
+            f = BytesIO()
             self.fig.savefig(f, format=self.frame_format,
                              dpi=self.dpi, **savefig_kwargs)
-            f.reset()
-            self._saved_frames.append(f.read().encode('base64'))
+            f.seek(0)
+            b = base64.b64encode(f.read())
+            self._saved_frames.append(b)
         #else:
             #return super(HTMLWriter, self).grab_frame(**savefig_kwargs)
 

--- a/src/python/visclaw/JSAnimation/html_writer.py
+++ b/src/python/visclaw/JSAnimation/html_writer.py
@@ -25,7 +25,7 @@ class _Icons(object):
     def _load_base64(self, filename):
         data = open(os.path.join(self.icon_dir, filename), 'rb').read()
         return 'data:image/{0};base64,{1}'.format(self.extension,
-                                        base64.b64encode(data))
+                                        base64.b64encode(data).decode())
 
 PREV_INCLUDE = """
 {add_html}
@@ -244,7 +244,7 @@ def _embedded_frames(frame_list, frame_format):
     embedded = "\n"
     for i, frame_data in enumerate(frame_list):
         embedded += template.format(i, frame_format,
-                                    frame_data.replace(b'\n', b'\\\n'))
+                                    frame_data.replace('\n', '\\\n'))
     return embedded
 
 
@@ -311,7 +311,7 @@ class HTMLWriter(FileMovieWriter):
             self.fig.savefig(f, format=self.frame_format,
                              dpi=self.dpi, **savefig_kwargs)
             f.seek(0)
-            b = base64.b64encode(f.read())
+            b = base64.b64encode(f.getvalue()).decode()
             self._saved_frames.append(b)
         #else:
             #return super(HTMLWriter, self).grab_frame(**savefig_kwargs)


### PR DESCRIPTION
This updates html_writer.py so that it works with both Python 2 and Python 3.  Thanks to @jakevdp for help with this.