### PR TITLE
need to import reload also in Python 2 now

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1464,11 +1464,10 @@ def call_setplot(setplot, plotdata, verbose=True):
     """
     import types
     # "reload" is only available from a module in Python 3.
-    if sys.version_info[0] >= 3:
-        if sys.version_info[1] >= 4:
-            from importlib import reload
-        else:
-            from imp import reload
+    if (sys.version_info[0] >= 3) and (sys.version_info[1] >= 4):
+        from importlib import reload
+    else:
+        from imp import reload
 
     # This is a bit of a hack to make sure that we still handle the
     # setplot == None case, we may want to deprecate this and require


### PR DESCRIPTION
#202 breaks Python 2 version, as the test below shows.  The solution is to always import `reload` from somewhere.  I guess `imp` is the right place, but @ketch or @quantheory might want to check this.

```
def test():
    import sys
    if sys.version_info[0] >= 3:
        if sys.version_info[1] >= 4:
            from importlib import reload
        else:
            from imp import reload
    reload(sys)
```

gives:

```
Traceback (most recent call last):
  File "test1.py", line 12, in <module>
    test()
  File "test1.py", line 10, in test
    reload(sys)
UnboundLocalError: local variable 'reload' referenced before assignment
```