### PR TITLE
Remove all uses of hold() command.

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -179,7 +179,6 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
             axescmd = getattr(plotaxes,'axescmd','subplot(1,1,1)')
             axescmd = 'plotaxes._handle = plt.%s' % axescmd
             exec(axescmd)
-            plt.hold(True)
 
             current_data.plotaxes = plotaxes
             current_data.plotfigure = plotaxes._plotfigure
@@ -547,8 +546,6 @@ def plotitem1(framesoln, plotitem, current_data, stateno):
 
     # The plot commands using matplotlib:
 
-    plt.hold(True)
-
     if pp['color']:
         pp['kwargs']['color'] = pp['color']
 
@@ -698,8 +695,6 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
         X_center, Y_center = xc_centers, yc_centers
         X_edge, Y_edge = xc_edges, yc_edges
 
-    plt.hold(True)
-
     if ma.isMaskedArray(var):
         # If var is a masked array: plotting should work ok unless all
         # values are masked, in which case pcolor complains and there's
@@ -789,8 +784,6 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
         elif pp['patch_bgcolor'] is not 'w':
             pobj = pc_mth(X_edge, Y_edge, np.zeros(var.shape), \
                     cmap=pp['patch_bgcolormap'], edgecolors='None')
-        plt.hold(True)
-
 
         if pp['plot_type'] == '2d_contour':
             # create the contour command:

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -250,9 +250,6 @@ def plotgauge(gaugeno, plotdata, verbose=False):
             axescmd = getattr(plotaxes,'axescmd','subplot(1,1,1)')
             axescmd = 'plotaxes._handle = pylab.%s' % axescmd
             exec(axescmd)
-            pylab.hold(True)
-
-
 
             # loop over items:
             # ----------------
@@ -419,9 +416,6 @@ def plotgauge1(gaugesoln, plotitem, current_data):
     varmax = var.max()
 
     # The plot commands using matplotlib:
-
-    pylab.hold(True)
-
     # Need to debug why gaugesoln.number always 1 here
     pylab.title("%s at Gauge %i" % (plotitem._plotaxes.title,\
                  gaugesoln.id))

--- a/src/python/visclaw/multiframetools.py
+++ b/src/python/visclaw/multiframetools.py
@@ -108,7 +108,6 @@ def plot_multiframes(plotdata, verbose=False):
             axescmd = getattr(plotaxes,'axescmd','subplot(1,1,1)')
             axescmd = 'plotaxes._handle = pylab.%s' % axescmd
             exec(axescmd)
-            pylab.hold(True)
 
             # loop over plotitems on these axes:
             # ----------------------------------


### PR DESCRIPTION
Our calls to `plt.hold(True)` now have no effect except to trigger
a deprecation warning.  This is because hold is set to True now by default.

**This PR is compatible only with matplotlib 2.0+**.

 It may be necessary in
some places to add calls to clf() since the default
behavior of matplotlib has changed (but that need is unaffected by this PR,
and that changed happened quite awhile ago, so I doubt that anything is needed).
