### PR TITLE
Auto-detect output format

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -229,7 +229,23 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if refresh or (key not in framesoln_dict):
-            framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
+
+            if self.format in [None,'ascii','binary']:
+                # check to see if outdir has a fort.b file for this frame
+                # if so assume binary output, otherwise assume ascii:
+                fortb = 'fort.b' + str(frameno).zfill(4)
+                if os.path.isfile(os.path.join(outdir,fortb)):
+                    file_format = 'binary'
+                else:
+                    file_format = 'ascii'
+                #print('+++ file_format appears to be %s' % file_format)
+            else:
+                # to allow other formats...
+                file_format = self.format
+    
+
+            framesoln = solution.Solution(frameno,path=outdir,
+                            file_format=file_format)
             if not self.save_frames:
                 framesoln_dict.clear()
             framesoln_dict[key] = framesoln

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -49,7 +49,7 @@ class ClawPlotData(clawdata.ClawData):
         else:
             self.add_attribute('rundir',os.getcwd())     # uses *.data from rundir
             self.add_attribute('outdir',os.getcwd())     # where to find fort.* files
-            self.add_attribute('format','ascii')
+            self.add_attribute('format',None)
 
         # This should eventually replace all need for recording the above
         # information
@@ -230,9 +230,10 @@ class ClawPlotData(clawdata.ClawData):
 
         if refresh or (key not in framesoln_dict):
 
-            if self.format in [None,'ascii','binary']:
+            if self.format == None:
                 # check to see if outdir has a fort.b file for this frame
-                # if so assume binary output, otherwise assume ascii:
+                # if so assume binary output, otherwise assume ascii.
+                # (eventually auto-detect other formats?)
                 fortb = 'fort.b' + str(frameno).zfill(4)
                 if os.path.isfile(os.path.join(outdir,fortb)):
                     file_format = 'binary'
@@ -240,7 +241,7 @@ class ClawPlotData(clawdata.ClawData):
                     file_format = 'ascii'
                 #print('+++ file_format appears to be %s' % file_format)
             else:
-                # to allow other formats...
+                # if user specivied format
                 file_format = self.format
     
 

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1681,9 +1681,10 @@ def load_frame(frameno, outdir='_output', format=None):
     Convenience function to load a frame of Clawpack output
     and return framesoln, a pyclaw.solution.Solution object.
     
-    format can be set for specific format such as 'netcdf', 
-    but if format in [None, 'ascii', 'binary'] then 
-    starting with commit 02e77f2b83, the format should be auto-detected.
+    format can be set for specific format such as 'netcdf'. 
+
+    If format is None, then starting with commit 02e77f2b83, 
+    the format should be auto-detected if it is either 'ascii' or 'binary'.
     """
 
     from clawpack.visclaw.data import ClawPlotData

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1674,3 +1674,22 @@ def set_show(plotdata):
                             plotfigure._show = True
 
     return plotdata
+
+        
+def load_frame(frameno, outdir='_output', format=None):
+    """
+    Convenience function to load a frame of Clawpack output
+    and return framesoln, a pyclaw.solution.Solution object.
+    
+    format can be set for specific format such as 'netcdf', 
+    but if format in [None, 'ascii', 'binary'] then 
+    starting with commit 02e77f2b83, the format should be auto-detected.
+    """
+
+    from clawpack.visclaw.data import ClawPlotData
+    plotdata = ClawPlotData()
+    plotdata.outdir = outdir
+    plotdata.format = format
+    framesoln = plotdata.getframe(frameno, plotdata.outdir)
+    return framesoln
+


### PR DESCRIPTION
Currently `plotdata.format` in `setplot.py` has to be consistent with `clawdata.output_format` in `setrun.py`.  If one is `ascii` and the other `binary` then obscure errors happen without explanation.

In the proposed change to `data.getframe`, if format is set to `None`, it checks if there are any `fort.b` files in the outdir and if so assumes `binary`, otherwise `ascii`.  

Are `hdf5` or `netcdf` in use and should we try to auto-detect those?

Note: This change is needed to allow a single `setplot` to load data from two different outdir's (for comparison plots) in the case they have different formats, not currently possible.  A future PR will support this.