### PR TITLE
Auto detect file format, second attempt

### DIFF
--- a/src/python/visclaw/Iplotclaw.py
+++ b/src/python/visclaw/Iplotclaw.py
@@ -235,6 +235,7 @@ class Iplotclaw(Iplot):
         print('plotgauge    : loop through plots of all gauges')
 
     def do_list(self, rest):
+        print('Frames found in %s:' % self.plotdata.outdir)
         frame_list = self.plotdata.getframe_list(self.plotdata.outdir)
         for frameno_t in frame_list:
             print('Frame number %i at time t = %g' % frameno_t)

--- a/src/python/visclaw/Iplotclaw.py
+++ b/src/python/visclaw/Iplotclaw.py
@@ -233,8 +233,15 @@ class Iplotclaw(Iplot):
         print('plotgauge n  : plot figure for gauge number n, if found')
         print('plotgauge all: loop through plots of all gauges')
         print('plotgauge    : loop through plots of all gauges')
+
+    def do_list(self, rest):
+        frame_list = self.plotdata.getframe_list(self.plotdata.outdir)
+        for frameno_t in frame_list:
+            print('Frame number %i at time t = %g' % frameno_t)
         
-        
+    def help_list(self):
+        print('print a list of frames and corresponding times from outdir')
+
     # Convenience functions for examining solution or making additional
     # plots from the ipython command line:
     # -----------------------------------------------------------------

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -49,7 +49,7 @@ class ClawPlotData(clawdata.ClawData):
         else:
             self.add_attribute('rundir',os.getcwd())     # uses *.data from rundir
             self.add_attribute('outdir',os.getcwd())     # where to find fort.* files
-            self.add_attribute('format','ascii')
+            self.add_attribute('format',None)
 
         # This should eventually replace all need for recording the above
         # information
@@ -229,6 +229,7 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if refresh or (key not in framesoln_dict):
+            print('+++ self.format = %s' % self.format)
             framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
             if not self.save_frames:
                 framesoln_dict.clear()

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -229,7 +229,6 @@ class ClawPlotData(clawdata.ClawData):
         key = (frameno, outdir)
 
         if refresh or (key not in framesoln_dict):
-            print('+++ self.format = %s' % self.format)
             framesoln = solution.Solution(frameno,path=outdir,file_format=self.format)
             if not self.save_frames:
                 framesoln_dict.clear()

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -54,8 +54,8 @@ class ClawPlotData(clawdata.ClawData):
         # This should eventually replace all need for recording the above
         # information
         self.add_attribute('output_controller', None)
-        self.output_controller = clawpack.pyclaw.controller.OutputController(
-                                           self.outdir, file_format=self.format)
+        #self.output_controller = clawpack.pyclaw.controller.OutputController(
+                                           #self.outdir, file_format=self.format)
 
 
         self.add_attribute('plotdir',os.getcwd())      # directory for plots *.png, *.html

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -245,6 +245,41 @@ class ClawPlotData(clawdata.ClawData):
         return framesoln
 
 
+    def getframe_time(self,frameno,outdir=None):
+        """
+        Attempt to read only the time of this frame, not the full solution.
+        This works if there is a fort.t file containing the time, as there is if
+        the output format is 'ascii' or 'binary'.
+        If that approach fails it loads the full solution and returns the time.
+        """
+        import os
+        if outdir is None:
+            outdir = self.outdir
+        outdir = os.path.abspath(outdir)
+        fname = 'fort.t%s' % str(frameno).zfill(4)
+        fname = os.path.join(outdir, fname)
+        try:
+            # assumes fort.t file exists and contains t on first line:
+            first_line = open(fname).readline()
+            t = float(first_line.split()[0])
+        except:
+            t = self.getframe(frameno, outdir).t
+        return t
+
+    def getframe_list(self, outdir=None):
+        import os
+        import glob
+        if outdir is None:
+            outdir = self.outdir
+        outdir = os.path.abspath(outdir)
+        fortt_list = glob.glob(os.path.join(outdir,'fort.t*'))
+        framenos = [int(s[-4:]) for s in fortt_list]
+        frame_list = []
+        for frameno in framenos:
+            frame_list.append((frameno, self.getframe_time(frameno, outdir)))
+        return frame_list
+
+
     def clearfigures(self):
         """
         Clear all plot parameters specifying figures, axes, items.

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -36,7 +36,7 @@ if sys.platform in ['win32','cygwin']:
 
 
 def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
-             format='ascii', msgfile='', frames=None, verbose=False):
+             format=None, msgfile='', frames=None, verbose=False):
     """
     Create html and/or latex versions of plots.
 
@@ -44,6 +44,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
         setplot is a module containing a function setplot that will be called
                 to set various plotting parameters.
         format specifies the format of the files output from Clawpack
+            format=None will try to auto-detect.
     """
 
     from clawpack.visclaw.data import ClawPlotData

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2927,12 +2927,12 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     fignames = plotdata._figname_from_num
 
     # Only grab times by loading in time
-    for frameno in framenos:
-        plotdata.output_controller.output_path = plotdata.outdir
-        frametimes[frameno] = plotdata.output_controller.get_time(frameno)
+    #for frameno in framenos:
+        #plotdata.output_controller.output_path = plotdata.outdir
+        #frametimes[frameno] = plotdata.output_controller.get_time(frameno)
 
-    # for frameno in framenos:
-    #     frametimes[frameno] = plotdata.getframe(frameno, plotdata.outdir).t
+    for frameno in framenos:
+        frametimes[frameno] = plotdata.getframe(frameno, plotdata.outdir).t
 
     plotdata.timeframes_framenos = framenos
     plotdata.timeframes_frametimes = frametimes

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2932,7 +2932,8 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
         #frametimes[frameno] = plotdata.output_controller.get_time(frameno)
 
     for frameno in framenos:
-        frametimes[frameno] = plotdata.getframe(frameno, plotdata.outdir).t
+        #frametimes[frameno] = plotdata.getframe(frameno, plotdata.outdir).t
+        frametimes[frameno] = plotdata.getframe_time(frameno, plotdata.outdir)
 
     plotdata.timeframes_framenos = framenos
     plotdata.timeframes_frametimes = frametimes


### PR DESCRIPTION
This requires clawpack/pyclaw#581.

The default `ClawPlotData.format` value is now `None`, indicating that pyclaw should figure it out for itself.

I added a function `ClawPlotData.getframe_time` that is now used in `plotpages.py` to only grab the times, in place of the deprecated `OutputController` function.

While I was at it, I also added a function `ClawPlotData.getframe_list` that returns a list of all the `framenos` found in `plotdata.outdir` and the corresponding time, and a function to `Iplotclaw` so that this can be easily invoked at the interactive `PLOTCLAW>` prompt, with output like this:

```
PLOTCLAW > list
Frames found in _output:
Frame number 0 at time t = 0
Frame number 1 at time t = 0.25
Frame number 2 at time t = 0.5
Frame number 3 at time t = 0.75
Frame number 4 at time t = 1
```

I've been meaning to do this for a long time!
