### PR TITLE
Add beforeaxes attribute to ClawPlotAxes and run it in plot_frame

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -651,6 +651,7 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('title_with_t',True)  # creates title of form 'title at time t = ...'
         self.add_attribute('axescmd','subplot(1,1,1)')
 
+        self.add_attribute('beforeaxes',None)
         self.add_attribute('afteraxes',None)
         self.add_attribute('xlimits',None)
         self.add_attribute('ylimits',None)

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -183,6 +183,9 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
             current_data.plotaxes = plotaxes
             current_data.plotfigure = plotaxes._plotfigure
 
+            beforeaxes = getattr(plotaxes,'beforeaxes',None)
+            current_data = run_str_or_func(beforeaxes,current_data)
+                
 
             # NOTE: This was rearranged December 2009 to
             # loop over patches first and then over plotitems so that


### PR DESCRIPTION
Useful to plot background image before each time frame plot, e.g. Google Earth
image for GeoClaw.  

For example, add something like this to the top of `setplot.py`:

```
image = plt.imread('image.png')

def background_image(current_data):
    from pylab import imshow
    extent = [x1,x2,y1,y2]
    imshow(image,extent=extent)
```

and then for some `ClawPlotAxes` setup:

```
    plotaxes.beforeaxes = background_image
```