### PR TITLE
add ClawPlotItem.colorbar_kwargs

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -788,6 +788,7 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('colorbar_label',None)
             self.add_attribute('colorbar_ticks', None)
             self.add_attribute('colorbar_tick_labels',None)
+            self.add_attribute('colorbar_kwargs',{})
             self.add_attribute('kwargs',{})
             amr_attributes = """celledges_show celledges_color data_show
               patch_bgcolor patchedges_show patchedges_color kwargs""".split()

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -784,7 +784,7 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('patchedges_show',0)
             self.add_attribute('patchedges_color','k')
             self.add_attribute('add_colorbar',False)
-            self.add_attribute('colorbar_shrink',1.0)
+            self.add_attribute('colorbar_shrink',None)
             self.add_attribute('colorbar_label',None)
             self.add_attribute('colorbar_ticks', None)
             self.add_attribute('colorbar_tick_labels',None)

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -320,9 +320,11 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         pass
                     elif plotitem.has_attribute('add_colorbar') and plotitem.add_colorbar:
                         pobj = plotitem._current_pobj # most recent plot object
-                        cbar = plt.colorbar(pobj, \
-                                     shrink=plotitem.colorbar_shrink,\
-                                     ticks=plotitem.colorbar_ticks)
+                        
+                        cbar = plt.colorbar(pobj,
+                                     shrink=plotitem.colorbar_shrink,
+                                     ticks=plotitem.colorbar_ticks,
+                                     **plotitem.colorbar_kwargs)
                         if plotitem.has_attribute('colorbar_tick_labels'):
                             if plotitem.colorbar_tick_labels is not None:
                                 cbar.ax.set_yticklabels(plotitem.colorbar_tick_labels)

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -320,11 +320,16 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         pass
                     elif plotitem.has_attribute('add_colorbar') and plotitem.add_colorbar:
                         pobj = plotitem._current_pobj # most recent plot object
-                        
-                        cbar = plt.colorbar(pobj,
-                                     shrink=plotitem.colorbar_shrink,
-                                     ticks=plotitem.colorbar_ticks,
-                                     **plotitem.colorbar_kwargs)
+                        # set dictionary values for keywords explicitly set:
+                        if plotitem.colorbar_shrink is not None:
+                            plotitem.colorbar_kwargs['shrink'] = \
+                                    plotitem.colorbar_shrink
+                        if plotitem.colorbar_ticks is not None:
+                            plotitem.colorbar_kwargs['ticks'] = \
+                                    plotitem.colorbar_ticks
+
+                        cbar = plt.colorbar(pobj, **plotitem.colorbar_kwargs)
+
                         if plotitem.has_attribute('colorbar_tick_labels'):
                             if plotitem.colorbar_tick_labels is not None:
                                 cbar.ax.set_yticklabels(plotitem.colorbar_tick_labels)


### PR DESCRIPTION
useful e.g. for adding arrows to colorbar when colors saturate, e.g.
    plotitem.colorbar_kwargs = {'extend': 'both'}