### PR TITLE
WIP:  use JSAnimation from mpl if available

### DIFF
--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -2,9 +2,9 @@
 This animation_tools module contains tools to create animations in Python and
 Jupyter notebooks.
 
-Three types of animations are supported: 
- - using the ipywidget interact to create a figure with a slider bar, 
- - using JSAnimation to create Javascript code that loops over a set of 
+Three types of animations are supported:
+ - using the ipywidget interact to create a figure with a slider bar,
+ - using JSAnimation to create Javascript code that loops over a set of
    images and adds controls to play as an animation.
  - creation of mp4 files using ffmpeg (provided this package is installed).
 
@@ -20,14 +20,21 @@ stand-alone files that can be viewed in other ways, including
  - A mp4 file,
  - A reStructured text file with the JSAnimation for inclusion in Sphinx docs.
 
-The utility function make_anim_from_plotdir can be used to convert the png 
+The utility function make_anim_from_plotdir can be used to convert the png
 files in a Clawpack _plots directory into standalone animations of the types
 listed above.  See the file make_anim.py for an example of how this can be
 invoked from an applications directory.
 
 See also:
- https://ipywidgets.readthedocs.io/en/latest/#ipywidgets
- https://github.com/jakevdp/JSAnimation
+  https://ipywidgets.readthedocs.io/en/latest/#ipywidgets
+
+
+JSAnimation was originally developed by Jake Vanderplas, see
+  https://github.com/jakevdp/JSAnimation
+
+This module now uses the `animation.FuncAnimation.to_jshtml` function 
+built into `matplotlib` since version 2.1.0, see
+  https://matplotlib.org/api/_as_gen/matplotlib.animation.Animation.html
 
 More documentation of these functions is needed and they can probably be
 improved.
@@ -35,7 +42,7 @@ improved.
 """
 
 # use Python 3 style print function rather than Python 2 print statements:
-from __future__ import print_function 
+from __future__ import print_function
 
 from IPython.display import display
 from matplotlib import image, animation
@@ -51,7 +58,7 @@ from JSAnimation import IPython_display
 def make_plotdir(plotdir='_plots', clobber=True):
     """
     Utility function to create a directory for storing a sequence of plot
-    files, or if the directory already exists, clear out any old plots.  
+    files, or if the directory already exists, clear out any old plots.
     If clobber==False then it will abort instead of deleting existing files.
     """
 
@@ -69,7 +76,7 @@ def make_plotdir(plotdir='_plots', clobber=True):
 def save_frame(frameno, plotdir='_plots', fname_base='frame', format='png',
                verbose=False, **kwargs):
     """
-    After giving matplotlib commands to create the plot for a single frame 
+    After giving matplotlib commands to create the plot for a single frame
     of the desired animation, this can be called to save the figure with
     the appropriate file name such as _plots/frame00001.png.
     """
@@ -95,11 +102,10 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=(10,6), dpi=None):
     import matplotlib
 
     if matplotlib.backends.backend in ['MacOSX']:
-        print("*** animation.FuncAnimation doesn't work with backend %s" \
-            % matplotlib.backends.backend)
+        print("*** animation.FuncAnimation doesn't work with backend %s"
+              % matplotlib.backends.backend)
         print("*** Suggest using 'Agg'")
         return
-        
 
     import glob   # for finding all files matching a pattern
 
@@ -124,7 +130,8 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=(10,6), dpi=None):
         return im,
 
     anim = animation.FuncAnimation(fig, animate, init_func=init,
-                          frames=len(filenames), interval=200, blit=True)
+                                   frames=len(filenames), interval=200,
+                                   blit=True)
 
     return anim
 
@@ -134,11 +141,10 @@ def JSAnimate_images(images, figsize=(10,6), dpi=None):
     import matplotlib
 
     if matplotlib.backends.backend in ['MacOSX']:
-        print("*** animation.FuncAnimation doesn't work with backend %s" \
-            % matplotlib.backends.backend)
+        print("*** animation.FuncAnimation doesn't work with backend %s"
+              % matplotlib.backends.backend)
         print("*** Suggest using 'Agg'")
         return
-        
 
     fig = plt.figure(figsize=figsize, dpi=None)
     ax = fig.add_axes([0, 0, 1, 1])
@@ -155,24 +161,20 @@ def JSAnimate_images(images, figsize=(10,6), dpi=None):
         return im,
 
     anim = animation.FuncAnimation(fig, animate, init_func=init,
-                          frames=len(images), interval=200, blit=True)
+                                   frames=len(images), interval=200,
+                                   blit=True)
 
     plt.close(fig)
     return anim
 
 
-def make_html(anim, file_name='anim.html', title=None, raw_html='', \
+def make_html(anim, file_name='anim.html', title=None, raw_html='',
               fps=None, embed_frames=True, default_mode='once'):
     """
     Take an animation created by make_anim and convert it into a stand-alone
     html file.
     """
-
-    from JSAnimation.IPython_display import anim_to_html
-
-
-    html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
-                 default_mode=default_mode)
+    html_body = anim.to_jshtml(fps, embed_frames, default_mode)
 
     html_file = open(file_name,'w')
     html_file.write("<html>\n <h1>%s</h1>\n" % title)
@@ -185,15 +187,10 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
 def make_rst(anim, file_name='anim.rst',
               fps=None, embed_frames=True, default_mode='once'):
     """
-    Take an animation created by make_anim and convert it into an rst file 
+    Take an animation created by make_anim and convert it into an rst file
     (reStructuredText, for inclusion in Sphinx documentation, for example).
     """
-
-    from JSAnimation.IPython_display import anim_to_html
-
-
-    rst_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
-                 default_mode=default_mode)
+    rst_body = anim.to_jshtml()
 
     rst_body = rst_body.split('\n')
 
@@ -238,20 +235,20 @@ def read_images(plotdir, fname_pattern='*.png'):
         images.append(im)
     return images
 
-def save_images(images, figsize=(8,6), plotdir='_plots', clobber=True, \
+def save_images(images, figsize=(8,6), plotdir='_plots', clobber=True,
                 fname_base='frame', format='png', verbose=False, **kwargs):
 
     make_plotdir(plotdir=plotdir, clobber=clobber)
-    for frameno,image in enumerate(images):
-        fig = imshow_noaxes(image, figsize)
+    for frameno, img in enumerate(images):
+        fig = imshow_noaxes(img, figsize)
         filename = '%s/%s%s.%s' % (plotdir, fname_base, str(frameno).zfill(5), format)
         plt.savefig(filename, format=format, **kwargs)
         plt.close(fig)
         if verbose:
             print("Saved ",filename)
 
-def save_figs(figs, plotdir='_plots', clobber=True, \
-                fname_base='frame', format='png', verbose=False, **kwargs):
+def save_figs(figs, plotdir='_plots', clobber=True,
+              fname_base='frame', format='png', verbose=False, **kwargs):
 
     make_plotdir(plotdir=plotdir, clobber=clobber)
     for frameno,fig in enumerate(figs):
@@ -264,7 +261,7 @@ def save_figs(figs, plotdir='_plots', clobber=True, \
 
 def make_image(fig, **kwargs):
     """
-    Take a matplotlib figure *fig* and convert it to an image *im* that 
+    Take a matplotlib figure *fig* and convert it to an image *im* that
     can be viewed with imshow.
     """
 
@@ -292,11 +289,12 @@ def imshow_noaxes(im, figsize=(8,6)):
     plt.imshow(im)
     ax.axis('off')
     return fig
-    
+
 def interact_animate_images(images, figsize=(10,6), manual=False, TextInput=False):
 
-    def display_frame(frameno): 
+    def display_frame(frameno):
         imshow_noaxes(images[frameno], figsize=figsize)
+        plt.show()
 
     if TextInput:
         if TextInput:
@@ -312,7 +310,7 @@ def interact_animate_images(images, figsize=(10,6), manual=False, TextInput=Fals
 
 def interact_animate_figs(figs, manual=False, TextInput=False):
 
-    def display_frame(frameno): 
+    def display_frame(frameno):
         display(figs[frameno])
 
     if TextInput:
@@ -328,14 +326,34 @@ def interact_animate_figs(figs, manual=False, TextInput=False):
         interact(display_frame, frameno=widget)
 
 
-def make_anim_from_plotdir(plotdir='_plots', fignos='all',
-        outputs=['mp4','html','rst'], file_name_prefix=None,
-        figsize=(5,4), dpi=None, fps=5):
+def animate_figs(figs, style='ipywidgets', figsize=(10,6), **kwargs):
+    """
+    Create an animation from a set of figures,
+    style = 'ipywidgets' or 'JSAnimation'
+    returns anim
+    """
+
+    images = make_images(figs)
+
+    if style == 'ipywidgets':
+        anim = interact_animate_images(images, figsize=figsize, **kwargs)
+    elif style == 'JSAnimation':
+        anim = JSAnimate_images(images, figsize=figsize, **kwargs)
+    else:
+        raise ValueError('** Unrecognized style = %s' % style)
+
+    return anim
+
+def make_anim_from_plotdir(plotdir='_plots', fignos='all', outputs=[],
+                           file_name_prefix='', figsize=(5,4), dpi=None,
+                           fps=5):
 
     """
-    After running `make plots` using VisClaw, convert the png files in 
-    the plots directory into stand-alone files that can be embedded in
-    webpages or Sphinx documentation.
+    After running `make plots` using VisClaw, convert the png files in
+    the plots directory into an animation, and perhaps also
+    stand-alone files that can be embedded in webpages or Sphinx documentation.
+
+    outputs can be a list containing any of 'mp4','html','rst'
 
     Call this from a script that starts with:
         import matplotlib
@@ -349,7 +367,7 @@ def make_anim_from_plotdir(plotdir='_plots', fignos='all',
         if len(movie_files) == 0:
             print('No movie files found in %s' % plotdir)
             return
-    
+
         fignos = []
         regexp = re.compile(r"movie[^ ]*fig(?P<figno>[0-9]*)[.html]")
         for f in movie_files:
@@ -357,7 +375,6 @@ def make_anim_from_plotdir(plotdir='_plots', fignos='all',
             fignos.append(result.group('figno'))
 
         print("Found these figures: %s" % fignos)
-    
 
     for figno in fignos:
 
@@ -366,17 +383,17 @@ def make_anim_from_plotdir(plotdir='_plots', fignos='all',
 
         if 'mp4' in outputs:
             file_name = file_name_prefix + 'fig%s.mp4' % figno
-            make_mp4(anim, file_name, fps=fps, \
-                embed_frames=True, default_mode='once')
+            make_mp4(anim, file_name, fps=fps,
+                     embed_frames=True, default_mode='once')
 
         if 'html' in outputs:
             file_name = file_name_prefix + 'fig%s.html' % figno
-            make_html(anim, file_name, fps=fps, \
-                embed_frames=True, default_mode='once')
+            make_html(anim, file_name, fps=fps,
+                      embed_frames=True, default_mode='once')
 
         if 'rst' in outputs:
             file_name = file_name_prefix + 'fig%s.rst' % figno
-            make_rst(anim, file_name, fps=fps, \
-                embed_frames=True, default_mode='once')
+            make_rst(anim, file_name, fps=fps,
+                     embed_frames=True, default_mode='once')
 
-
+    return anim

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2982,16 +2982,19 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
         except:
             print("*** Warning: Your version of matplotlib does not support\n"\
                   + "*** JSAnimation directly, version >= 2.2.0 suggested")
-            try:
-                # test if matplotlib supports local JSAnimation:
-                # this option is deprecated but here for backward compatibility
-                from .JSAnimation import HTMLWriter
-                from .JSAnimation.fix_jsmovies import fix_file
-                plotdata.html_movie = "JSAnimation_local"
-            except:
-                print("*** Warning: Your version of matplotlib does not support local JSAnimation")
-                print("*** Switching to 4.x style animation")
-                plotdata.html_movie = "4.x"
+            plotdata.html_movie = 'JSAnimation_local'
+            
+    if plotdata.html_movie == "JSAnimation_local":
+        try:
+            # test if matplotlib supports local JSAnimation:
+            # this option is deprecated but here for backward compatibility
+            from matplotlib import animation
+            from .JSAnimation import HTMLWriter
+            from .JSAnimation.fix_jsmovies import fix_file
+        except:
+            print("*** Warning: Your version of matplotlib does not support local JSAnimation")
+            print("*** Switching to 4.x style animation")
+            plotdata.html_movie = "4.x"
 
     os.chdir(plotdir)
 

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2981,7 +2981,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
             junk = animation.FuncAnimation.to_jshtml
         except:
             print("*** Warning: Your version of matplotlib does not support\n"\
-                  + "*** JSAnimation directly, version >= 2.2.0 suggested")
+                  + "*** JSAnimation directly, version >= 2.1.0 suggested")
             plotdata.html_movie = 'JSAnimation_local'
             
     if plotdata.html_movie == "JSAnimation_local":
@@ -3074,7 +3074,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     elif (plotdata.html_movie == "JSAnimation_local") and (len(framenos) > 0):
         
         # Added by @maojrs, Summer 2013, based on JSAnimation of @jakevdp
-        # Deprecated now that JSAnimation is in matplotlib version >= 2.2.0
+        # Deprecated now that JSAnimation is in matplotlib version >= 2.1.0
         # but many users may not have this yet.
 
         class myHTMLWriter(HTMLWriter):

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2975,15 +2975,23 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     # ---------------------------------------
 
     if plotdata.html_movie == "JSAnimation":
-        # Only import if we need it:
         try:
+            # test if matplotlib supports to_jshtml:
             from matplotlib import animation
-            from .JSAnimation import HTMLWriter
-            from .JSAnimation.fix_jsmovies import fix_file
+            junk = animation.FuncAnimation.to_jshtml
         except:
-            print("*** Warning: Your version of matplotlib may not support JSAnimation")
-            print("    Switching to 4.x style animation")
-            plotdata.html_movie = "4.x"
+            print("*** Warning: Your version of matplotlib does not support\n"\
+                  + "*** JSAnimation directly, version >= 2.2.0 suggested")
+            try:
+                # test if matplotlib supports local JSAnimation:
+                # this option is deprecated but here for backward compatibility
+                from .JSAnimation import HTMLWriter
+                from .JSAnimation.fix_jsmovies import fix_file
+                plotdata.html_movie = "JSAnimation_local"
+            except:
+                print("*** Warning: Your version of matplotlib does not support local JSAnimation")
+                print("*** Switching to 4.x style animation")
+                plotdata.html_movie = "4.x"
 
     os.chdir(plotdir)
 
@@ -3026,9 +3034,45 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     if plotdata.kml:
         plotpages.plotclaw2kml(plotdata)
 
+
+    # Create Animations
+
     if (plotdata.html_movie == "JSAnimation") and (len(framenos) > 0):
 
+        for figno in fignos_each_frame:
+            fname = '*fig' + str(figno) + '.png'
+            filenames=sorted(glob.glob(fname))
+            fig = plt.figure()
+            im = plt.imshow(Image.imread(filenames[0]))
+            plt.axis('off')
+            def init():
+                im.set_data(Image.imread(filenames[0]))
+                return im,
+
+            def animate(i):
+                image=Image.imread(filenames[i])
+                im.set_data(image)
+                return im,
+
+            anim = animation.FuncAnimation(fig, animate, init_func=init,
+                                          frames=len(filenames), blit=True)
+                                          
+            fname = 'movieframe_allframesfig%s.html' % figno
+
+            html_body = anim.to_jshtml(fps=10, embed_frames=True, 
+                                       default_mode='once')
+            html_file = open(fname,'w')
+            html_file.write("<html>\n <center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n")
+            html_file.write(html_body)
+            html_file.close()
+            print("Created JSAnimation for figure", figno)
+
+            
+    elif (plotdata.html_movie == "JSAnimation_local") and (len(framenos) > 0):
+        
         # Added by @maojrs, Summer 2013, based on JSAnimation of @jakevdp
+        # Deprecated now that JSAnimation is in matplotlib version >= 2.2.0
+        # but many users may not have this yet.
 
         class myHTMLWriter(HTMLWriter):
             """
@@ -3048,9 +3092,8 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
                 frame_fullname = self.file_names
                 return frame_fullname
 
-
-        # Create Animations
-
+        #set embed_frames=True to embed base64-encoded frames directly in the HTML
+        
         for figno in fignos_each_frame:
             fname = '*fig' + str(figno) + '.png'
             filenames=sorted(glob.glob(fname))
@@ -3067,18 +3110,21 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
             anim = animation.FuncAnimation(fig, animate, init_func=init,
                                           frames=len(filenames), blit=True)
+                                          
+            fname = 'movieframe_allframesfig%s.html' % figno
 
-            #set embed_frames=True to embed base64-encoded frames directly in the HTML
             pre_html = '<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>'
             myHTMLwriter=myHTMLWriter(embed_frames=False, frame_dir=os.getcwd(), \
                     add_html=pre_html, frame_width=500,file_names=filenames)
-            fname = 'movieframe_allframesfig%s.html' % figno
             anim.save(fname, writer=myHTMLwriter)
             print("Created JSAnimation for figure", figno)
             fix_file(fname, verbose=False)
             # Clean up animation temporary files of the form frame0000.png
             myHTMLwriter.clear_temp = True
             myHTMLwriter.cleanup()
+            print("Created JSAnimation for figure", figno)
+
+                
 
     #-----------
     # gif movie:


### PR DESCRIPTION
Addresses #223. 

Try to use JSAnimation from mpl if available, if not try to use local JSAnimation.

Leaving the local version in for now for two reasons:
1. Many users may not have an up-to-date matplotlib,
2. The mpl version is coming out ugly at the moment relative to old version.

Presumably the second issue can be fixed by improving the resolution of what is displayed by `imshow`.   Compare:

 - [local JSAnimation](http://faculty.washington.edu/rjl/misc/jsanimate_tests/_plots_local/movieframe_allframesfig2.html)
 - [from matplotlib](http://faculty.washington.edu/rjl/misc/jsanimate_tests/_plots_mpl/movieframe_allframesfig2.html)