### PR TITLE
Plot timing stats

### DIFF
--- a/src/python/visclaw/plot_timing_stats.py
+++ b/src/python/visclaw/plot_timing_stats.py
@@ -1,0 +1,164 @@
+"""
+Plot timing info found in timing.csv file.
+Requires modified valout function to print this info.
+
+This should be turned into a callable function with default colors, etc.
+
+"""
+
+
+from __future__ import print_function
+from pylab import *
+import os
+
+# Location of timing.csv files:
+outdir = '_output'
+
+make_pngs = True  # print plots?
+
+def make_png(fname):
+    savefig(fname)
+    #savefig(fname, bbox_inches='tight')
+    print('Created %s' % fname)
+
+# set desired units for simulation time and computer time,
+# based on length of run:
+
+simtime_units = 'seconds'
+comptime_units = 'seconds'
+
+if simtime_units == 'seconds':
+    simtime_factor = 1
+elif simtime_units == 'minutes':
+    simtime_factor = 60.
+elif simtime_units == 'hours':
+    simtime_factor = 3600.
+
+if comptime_units == 'seconds':
+    comptime_factor = 1
+elif comptime_units == 'minutes':
+    comptime_factor = 60.
+elif comptime_units == 'hours':
+    comptime_factor = 3600.
+
+
+timing_stats_file = os.path.join(outdir, 'timing.csv')
+timing_stats = loadtxt(timing_stats_file, skiprows=1, delimiter=',')
+ntimes = timing_stats.shape[0]
+nlevels = int(timing_stats.shape[1] / 3) - 1
+
+time = zeros(ntimes)
+total_cpu = zeros(ntimes)
+total_wall = zeros(ntimes)
+wtime = zeros((ntimes, nlevels))
+cpu = zeros((ntimes, nlevels))
+cells = zeros((ntimes, nlevels))
+
+for j in range(ntimes):
+    time[j] = timing_stats[j,0]
+    total_wall[j] = timing_stats[j,1]
+    total_cpu[j] = timing_stats[j,2]
+    for level in range(nlevels):
+        wtime[j, level] = timing_stats[j,3*level + 3]
+        cpu[j, level] = timing_stats[j,3*level + 4]
+        cells[j, level] = timing_stats[j,3*level + 5]
+    
+xlimits = [time.min()/simtime_factor, time.max()/simtime_factor]
+ylimits = [0, 1.1*total_cpu.max()/comptime_factor]
+
+# define colors
+#R = linspace(0.2,1,nlevels)
+#B = linspace(1,0.2,nlevels)
+#G = 0.2*ones(nlevels)
+#RGB = vstack((R,G,B)).T
+
+# define colors, with colors[0] used for overhead, colors[j] for level j >= 1
+colors = ['y'] + 3*['r','g','m','c','b']  # allow lots of levels
+
+
+figure(22)
+clf()
+sum_cells_over_levels = zeros(ntimes)
+for j in range(nlevels):
+    if max(cells[:,j]) == 0:
+        break
+    #plot(time/3600, cells[:,j], label='Level %s' % (j+1))
+    last_sum_cells = sum_cells_over_levels.copy()
+    sum_cells_over_levels += cells[:,j]
+    plot(time/simtime_factor, sum_cells_over_levels, 'k')
+    fill_between(time/simtime_factor, last_sum_cells, sum_cells_over_levels, 
+                 color=colors[j+1],
+                 label='Level %s' % (j+1))
+
+plot(time/simtime_factor, sum_cells_over_levels, 'k', lw=3, label='Total Cells')
+xlim(xlimits)
+ylim(0, 1.1*sum_cells_over_levels[-1])
+title('Cells updated on each level')
+xlabel('Simulation time (%s)' % simtime_units)
+ylabel('Grid cell updates')
+legend(loc='upper left')
+
+if make_pngs:
+    make_png('CellUpdates.png')
+
+
+figure(24)
+clf()
+sum_cpu_over_levels = zeros(ntimes)
+for j in range(nlevels):
+    if max(cpu[:,j]) == 0:
+        break
+    #plot(time/3600, cpu[:,j], label='Level %s' % (j+1))
+    last_sum_cpu = sum_cpu_over_levels.copy()
+    sum_cpu_over_levels += cpu[:,j]
+    fill_between(time/simtime_factor, last_sum_cpu/comptime_factor, 
+                 sum_cpu_over_levels/comptime_factor, 
+                 color=colors[j+1],
+                 label='Level %s' % (j+1))
+    plot(time/simtime_factor, sum_cpu_over_levels/comptime_factor, 'k')
+
+fill_between(time/simtime_factor, total_cpu/comptime_factor, 
+             sum_cpu_over_levels/comptime_factor, 
+             color=colors[0],
+             label='Overhead')
+plot(time/simtime_factor, total_cpu/comptime_factor, 'k', lw=3, label='Total CPU')
+xlim(xlimits)
+ylim(ylimits)
+title('CPU time on each level')
+xlabel('Simulation time (%s)' % simtime_units)
+ylabel('CPU time (%s)' % comptime_units)
+legend(loc='upper left')
+
+if make_pngs:
+    make_png('CPUtime.png')
+
+
+figure(25)
+clf()
+sum_wtime_over_levels = zeros(ntimes)
+for j in range(nlevels):
+    if max(wtime[:,j]) == 0:
+        break
+    last_sum_wtime = sum_wtime_over_levels.copy()
+    sum_wtime_over_levels += wtime[:,j]
+    fill_between(time/simtime_factor, last_sum_wtime/comptime_factor,
+                 sum_wtime_over_levels/comptime_factor, 
+                 color=colors[j+1],
+                 label='Level %s' % (j+1))
+    plot(time/simtime_factor, sum_wtime_over_levels/comptime_factor, 'k')
+
+fill_between(time/simtime_factor, total_wall/comptime_factor, 
+             sum_wtime_over_levels/comptime_factor, 
+             color=colors[0],
+             label='Overhead')
+plot(time/simtime_factor, total_wall/comptime_factor, 'k', lw=3, label='Total Wall')
+title('Wall time on each level')
+xlabel('Simulation time (%s)' % simtime_units)
+ylabel('CPU time (%s)' % comptime_units)
+legend(loc='upper left')
+xlim(xlimits)
+ylim(ylimits)
+
+if make_pngs:
+    make_png('WallTime.png')
+

--- a/src/python/visclaw/plot_timing_stats.py
+++ b/src/python/visclaw/plot_timing_stats.py
@@ -130,7 +130,7 @@ else:
 legend(loc='upper left')
 
 if make_pngs:
-    make_png('CellUpdates.png')
+    make_png('CumCellUpdates.png')
 
 
 figure(22)
@@ -157,7 +157,7 @@ ylabel('CPU time (%s)' % comptime_units)
 legend(loc='upper left')
 
 if make_pngs:
-    make_png('CPUtime.png')
+    make_png('CumCPUtime.png')
 
 
 figure(23)
@@ -185,7 +185,7 @@ xlim(xlimits)
 ylim(ylimits_comptime)
 
 if make_pngs:
-    make_png('WallTime.png')
+    make_png('CumWallTime.png')
 
 
 # d cells / dt:
@@ -233,7 +233,7 @@ else:
 legend(loc='upper left')
 
 if make_pngs:
-    make_png('dCellUpdates.png')
+    make_png('AveCellUpdates.png')
 
 
 # average cpu_time / dt:
@@ -287,13 +287,13 @@ xlim(xlimits)
 ylimits_avecomptime = [0, 1.2*dc_max]
 ylim(ylimits_avecomptime)
 
-title('CPU time / simulation time')
+title('Average CPU time / simulation time')
 xlabel('Simulation time t (%s)' % simtime_units)
 ylabel('CPU time / sim time')
 legend(loc='upper left')
 
 if make_pngs:
-    make_png('dCellUpdates.png')
+    make_png('AveCPUTime.png')
 
 
 
@@ -344,10 +344,10 @@ for n in range(1,ntimes):
 xlim(xlimits)
 #ylim(0, 1.2*dc_max)
 ylim(ylimits_avecomptime)
-title('Wall time / simulation time')
+title('Average Wall time / simulation time')
 xlabel('Simulation time t (%s)' % simtime_units)
 ylabel('wtime time / sim time')
 legend(loc='upper left')
 
 if make_pngs:
-    make_png('dCellUpdates.png')
+    make_png('AveWallTime.png')

--- a/src/python/visclaw/plot_timing_stats.py
+++ b/src/python/visclaw/plot_timing_stats.py
@@ -2,8 +2,24 @@
 Plot timing info found in timing.csv file.
 Requires modified valout function from Clawpack 5.5.0 to print this info.
 
-This might eventually be turned into a more general utility function in visclaw.
-For now, copy this file and modify it for your needs.
+To use:
+
+    - Run the Clawpack or GeoClaw code, and insure that the file `timing.csv`
+      was generated in the output directory `_output` (hard-wired below).
+
+    - Run this script in an IPython shell, Jupyter notebook, or via::
+
+         $ python $CLAW/visclaw/src/python/visclaw/plot_timing_stats.py
+
+    - If run from the command line, view the plots created as png files.
+
+This code should eventually be turned into a more general utility function with
+more options. For now, copy this file and modify it for your needs if necessary.
+
+Note: if you are doing a restart, the original `timing.csv` file will be
+overwritten.  So if you want to compute timings for the original plus the
+restarted runs together, you will have to save the original and 
+then combine the times appropriately. This script does not do that.
 """
 
 from __future__ import print_function
@@ -13,7 +29,7 @@ import os
 # Location of timing.csv files:
 outdir = '_output'
 
-make_pngs = False  # print plots?
+make_pngs = True  # print plots?
 
 def make_png(fname):
     savefig(fname)


### PR DESCRIPTION
Script `plot_timing_stats.py` added to visclaw to plot CPU and Wall time timings from the file `_output/timing.csv`.

Requires `valout` routine that writes this file, which has been merged already in AMRClaw, https://github.com/clawpack/amrclaw/pull/202, and is in the works for GeoClaw in https://github.com/clawpack/geoclaw/pull/322.

This code should eventually be turned into a more general utility function with more options.  

See docstring for usage.