### PR TITLE
Kml gauges

### DIFF
--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -1045,8 +1045,12 @@ def plotclaw2kml(plotdata):
 
             # plotdata.gauges_fignos
             # Not clear how to get the figure number for each gauge.   Assume that
-            # there is only one figure number for all gauges
+            # there is only one figure number figno for all gauges
             # If user has set 'gaugeno=[]', gauge files will not be added to the KMLfile. 
+            
+            if plotdata.gauges_fignos is not None:
+                figno = plotdata.gauges_fignos[0] # use just the first
+                
             figname = gauge_pngfile[gaugeno,figno]
 
             elev = 0

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -1022,11 +1022,15 @@ def plotclaw2kml(plotdata):
 
         # Loop over all gauges
         for gnum,gauge in enumerate(gauges):
+            gaugeno = int(gauge[0])
+            if plotdata.print_gaugenos != 'all':
+                if gaugeno not in plotdata.print_gaugenos:
+                    #print('+++ skipping gauge %i, not in print_gaugenos' % gaugeno)
+                    continue # to next gauge
             t1,t2 = gauge[3:5]
             x1,y1 = gauge[1:3]
             if plotdata.kml_map_topo_to_latlong is not None:
                 x1,y1 = plotdata.kml_map_topo_to_latlong(x1,y1)
-            gaugeno = int(gauge[0])
 
             # Get proper coordinates, otherwise placemark doesn't show up.
             if x1 > 180:


### PR DESCRIPTION
A couple fixes to kml files for gauges:
 - Only add gauges in `plotdata.print_gaugenos`
 - If multiple fignos for a gauge, use the first for the plot to put in kmlfile.
Not clear how best to support multiple plots for each gauge in kml.