### PR TITLE
Animation improvements

### DIFF
--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -4,8 +4,10 @@ Jupyter notebooks.
 
 Three types of animations are supported: 
  - using the ipywidget interact to create a figure with a slider bar, 
- - using JSAnimation to create Javascript code that loops over a set of 
-   images and adds controls to play as an animation.
+ - an `animation.FuncAnimation` object, which can be displayed using the
+   `to_jshtml` method in a notebook.
+   NOTE: this replaces the old JSAnimation tools, now incorporated into
+   matplotlib's `animation.FuncAnimation`.
  - creation of mp4 files using ffmpeg (provided this package is installed).
 
 The set of images to combine in an animation can be specified as a
@@ -27,25 +29,25 @@ invoked from an applications directory.
 
 See also:
  https://ipywidgets.readthedocs.io/en/latest/#ipywidgets
- https://github.com/jakevdp/JSAnimation
+ https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.animation.Animation.html
 
 More documentation of these functions is needed and they can probably be
 improved.
+
+Version: Updated 2020-04-09 for v5.7.0, but some things still need updating.
 
 """
 
 # use Python 3 style print function rather than Python 2 print statements:
 from __future__ import print_function 
 
-from IPython.display import display
+from IPython.display import display, HTML
 from matplotlib import image, animation
 from matplotlib import pyplot as plt
 from ipywidgets import interact, interact_manual
 import ipywidgets
 import io
 from matplotlib import pyplot as plt
-
-from JSAnimation import IPython_display
 
 
 def make_plotdir(plotdir='_plots', clobber=True):
@@ -105,6 +107,10 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=(10,6), dpi=None):
 
     # Find all frame files:
     filenames = glob.glob('%s/%s' % (plotdir, fname_pattern))
+    
+    if len(filenames)==0:
+        print('*** No files found matching %s/%s' % (plotdir, fname_pattern))
+        return None
 
     # sort them into increasing order:
     filenames=sorted(filenames)
@@ -126,11 +132,17 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=(10,6), dpi=None):
     anim = animation.FuncAnimation(fig, animate, init_func=init,
                           frames=len(filenames), interval=200, blit=True)
 
+    plt.close(fig)
+
     return anim
 
 
-def JSAnimate_images(images, figsize=(10,6), dpi=None):
+def animate_images(images, figsize=(10,6), dpi=None):
 
+    """
+    Convert a list of images to anim using animation.FuncAnimation.
+    """
+    
     import matplotlib
 
     if matplotlib.backends.backend in ['MacOSX']:
@@ -139,7 +151,7 @@ def JSAnimate_images(images, figsize=(10,6), dpi=None):
         print("*** Suggest using 'Agg'")
         return
         
-
+    # display each image in a new fig:
     fig = plt.figure(figsize=figsize, dpi=None)
     ax = fig.add_axes([0, 0, 1, 1])
     ax.axis('off')  # so there's not a second set of axes
@@ -161,19 +173,33 @@ def JSAnimate_images(images, figsize=(10,6), dpi=None):
     return anim
 
 
+def animate_figs(figs, figsize=(10,6), dpi=300):
+
+    """
+    Convert a list of figs to anim using animation.FuncAnimation.
+    """
+    
+    images = make_images(figs, dpi=dpi)
+    anim = animate_images(images, figsize=figsize, dpi=dpi)
+    return anim
+    
+    
 def make_html(anim, file_name='anim.html', title=None, raw_html='', \
               fps=None, embed_frames=True, default_mode='once'):
     """
-    Take an animation created by make_anim and convert it into a stand-alone
-    html file.
+    Take an animation anim created by animation.FuncAnimation or by
+    one of the other functions in this module, and convert it into a
+    stand-alone html file with specified title.
+    
+    raw_html Will be put in the html file before the figure.
     """
 
-    from JSAnimation.IPython_display import anim_to_html
 
+    #html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
+                 #default_mode=default_mode)
 
-    html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
-                 default_mode=default_mode)
-
+    html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
+                               default_mode=default_mode)
     html_file = open(file_name,'w')
     html_file.write("<html>\n <h1>%s</h1>\n" % title)
     html_file.write(raw_html)
@@ -185,15 +211,14 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
 def make_rst(anim, file_name='anim.rst',
               fps=None, embed_frames=True, default_mode='once'):
     """
-    Take an animation created by make_anim and convert it into an rst file 
+    Take an animation anim created by animation.FuncAnimation or by
+    one of the other functions in this module, and convert it into rst.
     (reStructuredText, for inclusion in Sphinx documentation, for example).
     """
 
-    from JSAnimation.IPython_display import anim_to_html
 
-
-    rst_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
-                 default_mode=default_mode)
+    rst_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
+                               default_mode=default_mode)
 
     rst_body = rst_body.split('\n')
 
@@ -328,7 +353,7 @@ def interact_animate_figs(figs, manual=False, TextInput=False):
         interact(display_frame, frameno=widget)
 
 
-def make_anim_from_plotdir(plotdir='_plots', fignos='all',
+def make_anim_outputs_from_plotdir(plotdir='_plots', fignos='all',
         outputs=['mp4','html','rst'], file_name_prefix=None,
         figsize=(5,4), dpi=None, fps=5):
 
@@ -379,4 +404,36 @@ def make_anim_from_plotdir(plotdir='_plots', fignos='all',
             make_rst(anim, file_name, fps=fps, \
                 embed_frames=True, default_mode='once')
 
+def animate_from_plotdir(plotdir, figno=None, figsize=(10,6), dpi=None, fps=5):
+    
+    import glob, re
+    
+    if figno is None:
+        # Try to determine figno from movie files
+        movie_files = glob.glob(plotdir + '/movie*html')
+        if len(movie_files) == 0:
+            print('No movie files found in %s' % plotdir)
+            return
+    
+        fignos = []
+        regexp = re.compile(r"movie[^ ]*fig(?P<figno>[0-9]*)[.html]")
+        for f in movie_files:
+            result = regexp.search(f)
+            fignos.append(result.group('figno'))
 
+        if len(fignos)==0:
+            print('Could not determine figno automatically')
+            return None
+            
+        if len(fignos) > 1:
+            print("Found multiple fignos: %s" % fignos)
+            
+        figno = int(fignos[0])
+        print("Using figno = %i" % figno)
+        
+    fname_pattern = 'frame*fig%s.png' % figno
+    anim = make_anim(plotdir, fname_pattern, figsize, dpi)
+    return anim
+        
+        
+        

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -3050,93 +3050,17 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
             fname = '*fig' + str(figno) + '.png'
             filenames=sorted(glob.glob(fname))
 
-            if 0:
-                # see new way below
-                # choose figsize to have right aspect ratio for image:
-                im0 = Image.imread(filenames[0])
-                #xin = im0.shape[1] / 250.
-                #yin = im0.shape[0] / 250.
-                #xin = im0.shape[1] / html_movie_dpi
-                #yin = im0.shape[0] / html_movie_dpi
-                xin = 6.
-                yin = xin * im0.shape[0]/im0.shape[1]
-                #print('+++ im0.shape, xin, yin: ',im0.shape, xin, yin)
-                fig = plt.figure(figsize=(xin,yin),dpi=html_movie_dpi)
-    
-                # using 'nearest' gives slightly better resolution:
-                im = plt.imshow(Image.imread(filenames[0]), interpolation='nearest')
-                plt.axis('off')  # suppress second axis around image
-                def init():
-                    im.set_data(Image.imread(filenames[0]))
-                    return im,
-    
-                def animate(i):
-                    image=Image.imread(filenames[i])
-                    im.set_data(image)
-                    return im,
-    
-                anim = animation.FuncAnimation(fig, animate, init_func=init,
-                                              frames=len(filenames), blit=True)
-    
-    
-                try:
-                    # this original approach gives better resolution movies
-                    # than using anim.to_jshtml, so try this first.  
-                    # It might fail with newer matplotlib versions.
-                    
-                    # Added by @maojrs, Summer 2013, based on JSAnimation of @jakevdp
-                    class myHTMLWriter(HTMLWriter):
-                        """
-                        Subclass to use JSAnimations for movies.
-                        """
-    
-                        def __init__(self, fps=10, codec=None, bitrate=None, extra_args=None,\
-                               metadata=None, embed_frames=False, frame_dir=None, add_html='', \
-                               frame_width=650, default_mode='once', file_names=None):
-                            self.file_names=file_names
-                            super(myHTMLWriter, self).__init__(fps=fps, codec=codec, bitrate=bitrate,
-                               extra_args=extra_args, metadata=metadata,
-                               embed_frames=embed_frames, frame_dir=frame_dir,
-                               add_html=add_html, frame_width=frame_width, default_mode=default_mode)
-    
-                        def get_all_framenames(self):
-                            frame_fullname = self.file_names
-                            return frame_fullname
-                            
-                    #set embed_frames=True to embed base64-encoded frames directly in the HTML
-                    pre_html = '<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>'
-    
-                    
-                    myHTMLwriter = myHTMLWriter(embed_frames=False, 
-                                                frame_dir=os.getcwd(), 
-                                                add_html=pre_html,
-                                                frame_width=plotdata.html_movie_width,
-                                                file_names=filenames)
-                    fname = 'movieframe_allframesfig%s.html' % figno
-                    anim.save(fname, writer=myHTMLwriter)
-                    print("Created JSAnimation for figure", figno)
-                    fix_file(fname, verbose=False)
-                    # Clean up animation temporary files of the form frame0000.png
-                    myHTMLwriter.clear_temp = True
-                    myHTMLwriter.cleanup()
-    
-                except:
-                    # anim.to_jshtml should replace our JSAnimation code above,
-                    # but we still need to figure out how to get full resolution of
-                    # the reloaded png figures when using this:
-                    html_text = '<html>\n<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n' \
-                     + anim.to_jshtml(default_mode='once') + '</html>\n'
-                     
-                    fname = 'movieframe_allframesfig%s.html' % figno
-                    open(fname, 'w').write(html_text)
-                    print("Created anim.to_jshtml for figure ", figno)
+            # RJL: This way gives better resolution although it basically does
+            # the same thing as the code I removed, so not sure why
 
-            ## This way gives better resolution, not sure why...
             raw_html = '<html>\n<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n'
             animation_tools.make_anim_outputs_from_plotdir(plotdir=plotdir,
                             file_name_prefix = 'movieframe_allframes',
                             figsize=None,
                             fignos=[figno], outputs=['html'], raw_html=raw_html)
+
+            # Note: setting figsize=None above chooses figsize with aspect
+            # ratio based on .png files read in, may fit better on page
                 
 
     #-----------

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2234,7 +2234,7 @@ def plotclaw2html(plotdata):
     if plotdata.gif_movie:
         html.write('<p><tr><td><b>gif Movies:</b></td>')
         for ifig in range(len(fignos)):
-            html.write('\n   <td><a href="movie%s.gif">%s</a></td>' \
+            html.write('\n   <td><a href="moviefig%s.gif">%s</a></td>' \
                            % (fignos[ifig],fignames[fignos[ifig]]))
         html.write('</tr>\n')
     html.write('<p>\n<tr><td><b>All Frames:</b></td> ')
@@ -3060,7 +3060,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
                 #yin = im0.shape[0] / html_movie_dpi
                 xin = 6.
                 yin = xin * im0.shape[0]/im0.shape[1]
-                print('+++ im0.shape, xin, yin: ',im0.shape, xin, yin)
+                #print('+++ im0.shape, xin, yin: ',im0.shape, xin, yin)
                 fig = plt.figure(figsize=(xin,yin),dpi=html_movie_dpi)
     
                 # using 'nearest' gives slightly better resolution:

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -11,6 +11,12 @@ import os, time, string, glob
 import sys
 from functools import wraps
 
+# increase resolution for images in animations:
+html_movie_dpi = 100
+import matplotlib as mpl
+mpl.rcParams['figure.dpi']= html_movie_dpi
+#print('+++ backend =',  mpl.rcParams['backend'])
+
 
 # Required for new animation style modified MAY 2013
 import numpy as np
@@ -20,6 +26,8 @@ import six
 from six.moves import range
 
 from clawpack.visclaw import gaugetools
+from clawpack.visclaw import animation_tools
+
 # Clawpack logo... not used on plot pages currently.
 clawdir = os.getenv('CLAW')
 if clawdir is not None:
@@ -3037,78 +3045,98 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     if (plotdata.html_movie == "JSAnimation") and (len(framenos) > 0):
 
         # Create Animations
-
+    
         for figno in fignos_each_frame:
             fname = '*fig' + str(figno) + '.png'
             filenames=sorted(glob.glob(fname))
-            fig = plt.figure()
-            # using 'nearest' gives slightly better resolution:
-            im = plt.imshow(Image.imread(filenames[0]), interpolation='nearest')
-            plt.axis('off')  # suppress second axis around image
-            def init():
-                im.set_data(Image.imread(filenames[0]))
-                return im,
 
-            def animate(i):
-                image=Image.imread(filenames[i])
-                im.set_data(image)
-                return im,
+            if 0:
+                # see new way below
+                # choose figsize to have right aspect ratio for image:
+                im0 = Image.imread(filenames[0])
+                #xin = im0.shape[1] / 250.
+                #yin = im0.shape[0] / 250.
+                #xin = im0.shape[1] / html_movie_dpi
+                #yin = im0.shape[0] / html_movie_dpi
+                xin = 6.
+                yin = xin * im0.shape[0]/im0.shape[1]
+                print('+++ im0.shape, xin, yin: ',im0.shape, xin, yin)
+                fig = plt.figure(figsize=(xin,yin),dpi=html_movie_dpi)
+    
+                # using 'nearest' gives slightly better resolution:
+                im = plt.imshow(Image.imread(filenames[0]), interpolation='nearest')
+                plt.axis('off')  # suppress second axis around image
+                def init():
+                    im.set_data(Image.imread(filenames[0]))
+                    return im,
+    
+                def animate(i):
+                    image=Image.imread(filenames[i])
+                    im.set_data(image)
+                    return im,
+    
+                anim = animation.FuncAnimation(fig, animate, init_func=init,
+                                              frames=len(filenames), blit=True)
+    
+    
+                try:
+                    # this original approach gives better resolution movies
+                    # than using anim.to_jshtml, so try this first.  
+                    # It might fail with newer matplotlib versions.
+                    
+                    # Added by @maojrs, Summer 2013, based on JSAnimation of @jakevdp
+                    class myHTMLWriter(HTMLWriter):
+                        """
+                        Subclass to use JSAnimations for movies.
+                        """
+    
+                        def __init__(self, fps=10, codec=None, bitrate=None, extra_args=None,\
+                               metadata=None, embed_frames=False, frame_dir=None, add_html='', \
+                               frame_width=650, default_mode='once', file_names=None):
+                            self.file_names=file_names
+                            super(myHTMLWriter, self).__init__(fps=fps, codec=codec, bitrate=bitrate,
+                               extra_args=extra_args, metadata=metadata,
+                               embed_frames=embed_frames, frame_dir=frame_dir,
+                               add_html=add_html, frame_width=frame_width, default_mode=default_mode)
+    
+                        def get_all_framenames(self):
+                            frame_fullname = self.file_names
+                            return frame_fullname
+                            
+                    #set embed_frames=True to embed base64-encoded frames directly in the HTML
+                    pre_html = '<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>'
+    
+                    
+                    myHTMLwriter = myHTMLWriter(embed_frames=False, 
+                                                frame_dir=os.getcwd(), 
+                                                add_html=pre_html,
+                                                frame_width=plotdata.html_movie_width,
+                                                file_names=filenames)
+                    fname = 'movieframe_allframesfig%s.html' % figno
+                    anim.save(fname, writer=myHTMLwriter)
+                    print("Created JSAnimation for figure", figno)
+                    fix_file(fname, verbose=False)
+                    # Clean up animation temporary files of the form frame0000.png
+                    myHTMLwriter.clear_temp = True
+                    myHTMLwriter.cleanup()
+    
+                except:
+                    # anim.to_jshtml should replace our JSAnimation code above,
+                    # but we still need to figure out how to get full resolution of
+                    # the reloaded png figures when using this:
+                    html_text = '<html>\n<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n' \
+                     + anim.to_jshtml(default_mode='once') + '</html>\n'
+                     
+                    fname = 'movieframe_allframesfig%s.html' % figno
+                    open(fname, 'w').write(html_text)
+                    print("Created anim.to_jshtml for figure ", figno)
 
-            anim = animation.FuncAnimation(fig, animate, init_func=init,
-                                          frames=len(filenames), blit=True)
-
-
-            try:
-                # this original approach gives better resolution movies
-                # than using anim.to_jshtml, so try this first.  
-                # It might fail with newer matplotlib versions.
-                
-                # Added by @maojrs, Summer 2013, based on JSAnimation of @jakevdp
-                class myHTMLWriter(HTMLWriter):
-                    """
-                    Subclass to use JSAnimations for movies.
-                    """
-
-                    def __init__(self, fps=10, codec=None, bitrate=None, extra_args=None,\
-                           metadata=None, embed_frames=False, frame_dir=None, add_html='', \
-                           frame_width=650, default_mode='once', file_names=None):
-                        self.file_names=file_names
-                        super(myHTMLWriter, self).__init__(fps=fps, codec=codec, bitrate=bitrate,
-                           extra_args=extra_args, metadata=metadata,
-                           embed_frames=embed_frames, frame_dir=frame_dir,
-                           add_html=add_html, frame_width=frame_width, default_mode=default_mode)
-
-                    def get_all_framenames(self):
-                        frame_fullname = self.file_names
-                        return frame_fullname
-                        
-                #set embed_frames=True to embed base64-encoded frames directly in the HTML
-                pre_html = '<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>'
-
-                
-                myHTMLwriter = myHTMLWriter(embed_frames=False, 
-                                            frame_dir=os.getcwd(), 
-                                            add_html=pre_html,
-                                            frame_width=plotdata.html_movie_width,
-                                            file_names=filenames)
-                fname = 'movieframe_allframesfig%s.html' % figno
-                anim.save(fname, writer=myHTMLwriter)
-                print("Created JSAnimation for figure", figno)
-                fix_file(fname, verbose=False)
-                # Clean up animation temporary files of the form frame0000.png
-                myHTMLwriter.clear_temp = True
-                myHTMLwriter.cleanup()
-
-            except:
-                # anim.to_jshtml should replace our JSAnimation code above,
-                # but we still need to figure out how to get full resolution of
-                # the reloaded png figures when using this:
-                html_text = '<html>\n<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n' \
-                 + anim.to_jshtml() + '</html>\n'
-                 
-                fname = 'movieframe_allframesfig%s.html' % figno
-                open(fname, 'w').write(html_text)
-                print("Created anim.to_jshtml for figure ", figno)
+            ## This way gives better resolution, not sure why...
+            raw_html = '<html>\n<center><h3><a href=_PlotIndex.html>Plot Index</a></h3>\n'
+            animation_tools.make_anim_outputs_from_plotdir(plotdir=plotdir,
+                            file_name_prefix = 'movieframe_allframes',
+                            figsize=None,
+                            fignos=[figno], outputs=['html'], raw_html=raw_html)
                 
 
     #-----------


### PR DESCRIPTION
I think I finally got the `anim.to_jshtml` working better so the quality of animations on html pages created by `make plots`  is much better than what's shown in #245.  I'm not sure why, since I am now calling a function from `animation_tools` that does (I think) essentially exactly the same thing as the earlier code, but somehow it works better.  I still don't completely understand what's going on.

Anyway, I have now removed the dependence on our old `JSAnimation` completely and just use what's built in to matplotlib.  So this won't work with old versions of matplotlib, but since we are now only supporting Python3 officially I think this is ok?

Others should try it out and let me know about any problems before merging.

This PR also includes several changes to `animation_tools` to fix some things that were broke and to give greater functionality.  I've also been testing this on some notebooks, in particular some in the apps repository and I'll do a PR for those.

This could still use some cleaning up, at some point.