### PR TITLE
Skip patches not seen

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -209,6 +209,23 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                 for stateno,state in enumerate(framesoln.states):
 
                     patch = state.patch
+                    if (plotaxes.xlimits is not None) \
+                            & (type(plotaxes.xlimits) is not str):
+                        if (patch.dimensions[0].lower \
+                                    >= plotaxes.xlimits[1]) \
+                                or  (patch.dimensions[0].upper \
+                                    <= plotaxes.xlimits[0]):
+                            continue  # go to next patch
+
+                    if len(patch.dimensions) > 1:
+                        # 2d patch
+                        if (plotaxes.ylimits is not None) \
+                                & (type(plotaxes.ylimits) is not str):
+                            if (patch.dimensions[1].lower \
+                                        >= plotaxes.ylimits[1]) \
+                                    or  (patch.dimensions[1].upper \
+                                        <= plotaxes.ylimits[0]):
+                                continue  # go to next patch
 
                     current_data.add_attribute('patch',patch)
                     current_data.add_attribute("level",1)

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -206,15 +206,18 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                 # loop over patches:
                 # ----------------
 
+                num_skipped = 0
                 for stateno,state in enumerate(framesoln.states):
 
                     patch = state.patch
+
                     if (plotaxes.xlimits is not None) \
                             & (type(plotaxes.xlimits) is not str):
                         if (patch.dimensions[0].lower \
                                     >= plotaxes.xlimits[1]) \
                                 or  (patch.dimensions[0].upper \
                                     <= plotaxes.xlimits[0]):
+                            num_skipped += 1
                             continue  # go to next patch
 
                     if len(patch.dimensions) > 1:
@@ -225,6 +228,7 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                                         >= plotaxes.ylimits[1]) \
                                     or  (patch.dimensions[1].upper \
                                         <= plotaxes.ylimits[0]):
+                                num_skipped += 1
                                 continue  # go to next patch
 
                     current_data.add_attribute('patch',patch)
@@ -322,6 +326,11 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
 
                     # end of loop over plotitems
                 # end of loop over patches
+
+            if False and num_skipped > 0:
+                # possible warning message:
+                print('Skipped plotting %i patches not visible' % num_skipped)
+
             # end of loop over framesolns
 
 


### PR DESCRIPTION
When looping over patches this version skips a patch if it has no intersection with the region specified by `plotaxes.xlimits` and `plotaxes.ylimits`.  This speeds up plotting substantially for some problems, if you want to zoom in on different regions in different plots and have thousands of patches that can be ignored in each case.   This is distinct from what's proposed in #246 but useful in some contexts.

Note a possible problem is that if a user creates a figure with specified `xlimits` and `ylimits` but then gives additional `xlim`, `ylim`, or `axis` commands to zoom out, then some patches will not be seen that should be seen in the wider view, which could be misleading or confusing.  I'm ok with this but others may differ.