### PR TITLE
add option to suppress skipping patches

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -656,6 +656,7 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('afteraxes',None)
         self.add_attribute('xlimits',None)
         self.add_attribute('ylimits',None)
+        self.add_attribute('skip_patches_outside_xylimits',True)
         self.add_attribute('scaled',False)   # true so x- and y-axis scaled same
         self.add_attribute('image',False)    # true so x- and y-axis scaled same
                                              # and plot bounds tight

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -207,29 +207,34 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                 # ----------------
 
                 num_skipped = 0
+                skip_patches_outside_xylimits = \
+                        getattr(plotaxes,'skip_patches_outside_xylimits',True)
+
                 for stateno,state in enumerate(framesoln.states):
 
                     patch = state.patch
 
-                    if (plotaxes.xlimits is not None) \
-                            & (type(plotaxes.xlimits) is not str):
-                        if (patch.dimensions[0].lower \
-                                    >= plotaxes.xlimits[1]) \
-                                or  (patch.dimensions[0].upper \
-                                    <= plotaxes.xlimits[0]):
-                            num_skipped += 1
-                            continue  # go to next patch
-
-                    if len(patch.dimensions) > 1:
-                        # 2d patch
-                        if (plotaxes.ylimits is not None) \
-                                & (type(plotaxes.ylimits) is not str):
-                            if (patch.dimensions[1].lower \
-                                        >= plotaxes.ylimits[1]) \
-                                    or  (patch.dimensions[1].upper \
-                                        <= plotaxes.ylimits[0]):
+                    if skip_patches_outside_xylimits:
+                        # skip patches not visible based on xlimits,ylimits:
+                        if (plotaxes.xlimits is not None) \
+                                & (type(plotaxes.xlimits) is not str):
+                            if (patch.dimensions[0].lower \
+                                        >= plotaxes.xlimits[1]) \
+                                    or  (patch.dimensions[0].upper \
+                                        <= plotaxes.xlimits[0]):
                                 num_skipped += 1
                                 continue  # go to next patch
+    
+                        if len(patch.dimensions) > 1:
+                            # 2d patch
+                            if (plotaxes.ylimits is not None) \
+                                    & (type(plotaxes.ylimits) is not str):
+                                if (patch.dimensions[1].lower \
+                                            >= plotaxes.ylimits[1]) \
+                                        or  (patch.dimensions[1].upper \
+                                            <= plotaxes.ylimits[0]):
+                                    num_skipped += 1
+                                    continue  # go to next patch
 
                     current_data.add_attribute('patch',patch)
                     current_data.add_attribute("level",1)


### PR DESCRIPTION
If `plotaxes.skip_patches_outside_xylimits = False` then all patches will be plotted, even if outside the specified limits.  Default is `True`.

Addresses concerns in #262.