### PR TITLE
improve margins on savefig command for kml

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1077,10 +1077,14 @@ def printfig(fname='',frameno='', figno='', format='png', plotdir='.', \
         a.set_yticks([])
 
         plt.axis('off')
+
         if kml_figsize is not None:
             fig.set_size_inches(kml_figsize[0],kml_figsize[1])
-        plt.savefig(fname, transparent=True, bbox_inches='tight', \
-                      pad_inches=0,dpi=kml_dpi)
+        a.set_frame_on(False)
+        plt.subplots_adjust(top = 1, bottom = 0, right = 1, left = 0, 
+                        hspace = 0, wspace = 0)
+        plt.margins(0,0)
+        plt.savefig(fname, transparent=True, bbox_inches='tight',dpi=kml_dpi)
     else:
         plt.savefig(fname, bbox_inches=bbox_inches)
 


### PR DESCRIPTION
The `pad_inches` version stopped working for me, so I changed this to what is now done in `geoclaw.kmltools.pcolorcells_for_kml`.