### PR TITLE
To jshtml failure

### DIFF
--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -93,11 +93,8 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=None, dpi=None):
     import matplotlib
 
     if matplotlib.backends.backend in ['MacOSX']:
-        print("*** animation.FuncAnimation doesn't work with backend %s" \
-            % matplotlib.backends.backend)
-        print("*** Suggest using 'Agg'")
-        msg = "*** animation.FuncAnimation doesn't work with backend %s" \
-            % matplotlib.backends.backend
+        msg = "\n*** animation.FuncAnimation doesn't work with backend %s" \
+            % matplotlib.backends.backend + "\n*** Suggest using 'Agg'"
         warnings.warn(msg)
         return
         
@@ -108,7 +105,7 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=None, dpi=None):
     filenames = glob.glob('%s/%s' % (plotdir, fname_pattern))
     
     if len(filenames)==0:
-        msg = '*** No files found matching %s/%s' % (plotdir, fname_pattern)
+        msg = '\n*** No files found matching %s/%s' % (plotdir, fname_pattern)
         warnings.warn(msg)
         return None
 
@@ -208,8 +205,8 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
         html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
                                    default_mode=default_mode)
     except:
-        msg = '*** anim.to_jshtml() failed, not making animation\n' \
-              + '*** you may need to update your version of matplotlib'
+        msg = '\n*** anim.to_jshtml() failed, not making animation' \
+              + '\n*** you may need to update your version of matplotlib'
         warnings.warn(msg)
         html_body = '<h2>Unable to make animation</h2>\n' + \
                     '<h3>Consider updating matplotlib</h3>\n'
@@ -260,7 +257,7 @@ def make_mp4(anim, file_name='anim.mp4',
         return
 
     if os.path.splitext(file_name)[1] != '.mp4':
-        msg = "*** Might not work if file extension is not .mp4"
+        msg = "\n*** Might not work if file extension is not .mp4"
         warnings.warn(msg)
     if fps is None:
         fps = 3

--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -199,9 +199,6 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
     """
 
 
-    #html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
-                 #default_mode=default_mode)
-
     try:
         html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
                                    default_mode=default_mode)

--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -43,6 +43,7 @@ from __future__ import print_function
 
 from matplotlib import image, animation
 from matplotlib import pyplot as plt
+import warnings
 
 
 def make_plotdir(plotdir='_plots', clobber=True):
@@ -95,6 +96,9 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=None, dpi=None):
         print("*** animation.FuncAnimation doesn't work with backend %s" \
             % matplotlib.backends.backend)
         print("*** Suggest using 'Agg'")
+        msg = "*** animation.FuncAnimation doesn't work with backend %s" \
+            % matplotlib.backends.backend
+        warnings.warn(msg)
         return
         
 
@@ -104,7 +108,8 @@ def make_anim(plotdir, fname_pattern='frame*.png', figsize=None, dpi=None):
     filenames = glob.glob('%s/%s' % (plotdir, fname_pattern))
     
     if len(filenames)==0:
-        print('*** No files found matching %s/%s' % (plotdir, fname_pattern))
+        msg = '*** No files found matching %s/%s' % (plotdir, fname_pattern)
+        warnings.warn(msg)
         return None
 
     # sort them into increasing order:
@@ -203,8 +208,9 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
         html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
                                    default_mode=default_mode)
     except:
-        print('*** anim.to_jshtml() failed, not making animation')
-        print('*** you may need to update your version of matplotlib')
+        msg = '*** anim.to_jshtml() failed, not making animation\n' \
+              + '*** you may need to update your version of matplotlib'
+        warnings.warn(msg)
         html_body = '<h2>Unable to make animation</h2>\n' + \
                     '<h3>Consider updating matplotlib</h3>\n'
 
@@ -254,7 +260,8 @@ def make_mp4(anim, file_name='anim.mp4',
         return
 
     if os.path.splitext(file_name)[1] != '.mp4':
-        print("*** Might not work if file extension is not .mp4")
+        msg = "*** Might not work if file extension is not .mp4"
+        warnings.warn(msg)
     if fps is None:
         fps = 3
     writer = animation.writers['ffmpeg'](fps=fps)

--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -202,8 +202,15 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='', \
     #html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
                  #default_mode=default_mode)
 
-    html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
-                               default_mode=default_mode)
+    try:
+        html_body = anim.to_jshtml(fps=fps, embed_frames=embed_frames, \
+                                   default_mode=default_mode)
+    except:
+        print('*** anim.to_jshtml() failed, not making animation')
+        print('*** you may need to update your version of matplotlib')
+        html_body = '<h2>Unable to make animation</h2>\n' + \
+                    '<h3>Consider updating matplotlib</h3>\n'
+
     html_file = open(file_name,'w')
     if title is not None:
         html_file.write("<html>\n <h1>%s</h1>\n" % title)


### PR DESCRIPTION
When using an old version of matplotlib, the current version dies and screws up the terminal read_line in the process somehow when doing `make plots`.