### PR TITLE
Revert to BoundaryNorm if TwoSlopeNorm not found

### DIFF
--- a/src/python/visclaw/colormaps.py
+++ b/src/python/visclaw/colormaps.py
@@ -152,7 +152,7 @@ def add_colormaps(colormaps, data_limits=[0.0,1.0], data_break=0.5,
     try:
         # Use this norm for proportional pw linear with better tick mark locations:
         norm = colors.TwoSlopeNorm(data_break, data_limits[0], data_limits[1])
-    except:
+    except AttributeError:
         # older matplotlib.colors did not have TwoSlopeNorm, revert to old:
         norm = colors.BoundaryNorm(boundaries=bounds, ncolors=N)
 

--- a/src/python/visclaw/colormaps.py
+++ b/src/python/visclaw/colormaps.py
@@ -149,8 +149,12 @@ def add_colormaps(colormaps, data_limits=[0.0,1.0], data_break=0.5,
                                                              int(N / 2) + N % 2)
     #norm = colors.BoundaryNorm(boundaries=bounds, ncolors=N)
 
-    # Use this norm for proportional pw linear with better tick mark locations:
-    norm = colors.TwoSlopeNorm(data_break, data_limits[0], data_limits[1])
+    try:
+        # Use this norm for proportional pw linear with better tick mark locations:
+        norm = colors.TwoSlopeNorm(data_break, data_limits[0], data_limits[1])
+    except:
+        # older matplotlib.colors did not have TwoSlopeNorm, revert to old:
+        norm = colors.BoundaryNorm(boundaries=bounds, ncolors=N)
 
     return cmap, norm
 


### PR DESCRIPTION
In add_colormaps, the improved version doesn't work with older versions of
matplotlib.