### PR TITLE
make plot_timing_stats more robust

### DIFF
--- a/src/python/visclaw/plot_timing_stats.py
+++ b/src/python/visclaw/plot_timing_stats.py
@@ -211,7 +211,8 @@ def make_plots(outdir='_output', make_pngs=True, make_html=None,
 
     # Read in timing states from output directory:
     timing_stats_file = os.path.join(outdir, 'timing.csv')
-    timing_stats = loadtxt(timing_stats_file, skiprows=1, delimiter=',')
+    timing_stats = loadtxt(timing_stats_file, skiprows=1, delimiter=',',
+                           ndmin=2)
     ntimes = timing_stats.shape[0]
     nlevels = int(timing_stats.shape[1] / 3) - 1
 


### PR DESCRIPTION
Add `ndmin=2` to `loadtxt` command in case the file only has one line.