### PR TITLE
Rasterize fix

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -823,9 +823,11 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
                     norm=color_norm)
 
             if pp['celledges_show']:
-                # This draws patch for labels shown.  Levels not shown will
-                # not have lower levels blanked out however.  There doesn't
-                # seem to be an easy way to do this.
+                # This draws cell edges for this level.
+                # Note that these will still be visible when imshow is used
+                # for finer levels, so imshow doesn't look as good as pcolor
+                # when you only want to show celledges on coarse levels.
+                # There doesn't seem to be an easy way to fix this.
                 pobj = plt.plot(X_edge, Y_edge, color=pp['celledges_color'])
                 pobj = plt.plot(X_edge.T, Y_edge.T, color=pp['celledges_color'])
 

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -792,7 +792,8 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
         else:
             pcolor_cmd += ", shading='flat'"
         
-        pcolor_cmd += ", rasterized=True"
+        if 'rasterized' not in pp['kwargs']:
+            pcolor_cmd += ", rasterized=True"
         
         pcolor_cmd += ", **pp['kwargs'])"
 


### PR DESCRIPTION
This fix is needed in order to allow setting
```
    plotitem.kwargs = {'rasterized':False}
```

Also, more tests with `imshow` indicate that the file size doesn't vary based on `rasterized`.  I was also reminded that `imshow` doesn't work well if you want to show cell edges on some levels but not on finer ones and I fixed a comment to make this clearer.   Since `pcolor` now uses `pcolormesh` for most cases, which makes smaller images, I don't think there's much reason to use `imshow` and personally I don't use it for plotitems.