### PR TITLE
Add more attributes to some plot classes to simplify things commonly done

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -692,12 +692,12 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('xticks_kwargs', {}) # e.g. to set ticks,rotation
         self.add_attribute('yticks_fontsize', None) 
         self.add_attribute('yticks_kwargs', {}) # e.g. to set ticks
-        self.add_attribute('x_label', None) # label for x-axis
-        self.add_attribute('y_label', None) # label for y-axis
-        self.add_attribute('x_label_fontsize', None)
-        self.add_attribute('y_label_fontsize', None)
-        self.add_attribute('x_label_kwargs', {})
-        self.add_attribute('y_label_kwargs', {})
+        self.add_attribute('xlabel', None) # label for x-axis
+        self.add_attribute('ylabel', None) # label for y-axis
+        self.add_attribute('xlabel_fontsize', None)
+        self.add_attribute('ylabel_fontsize', None)
+        self.add_attribute('xlabel_kwargs', {})
+        self.add_attribute('ylabel_kwargs', {})
 
 
     def new_plotitem(self, name=None, plot_type=None):

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -685,12 +685,17 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('kwargs', {})
         self.add_attribute('grid', None) # True to add grid() command
         self.add_attribute('grid_kwargs', {}) # argument to grid() command
-        self.add_attribute('title_kwargs', {}) # e.g. to set fontsize
+        self.add_attribute('title_fontsize', None)
+        self.add_attribute('title_kwargs', {}) # e.g. to set color
         self.add_attribute('title_t_format', None) # format for t in title
-        self.add_attribute('xticks_kwargs', {}) # e.g. to set fontsize
-        self.add_attribute('yticks_kwargs', {}) # e.g. to set fontsize
+        self.add_attribute('xticks_fontsize', None) 
+        self.add_attribute('xticks_kwargs', {}) # e.g. to set ticks,rotation
+        self.add_attribute('yticks_fontsize', None) 
+        self.add_attribute('yticks_kwargs', {}) # e.g. to set ticks
         self.add_attribute('x_label', None) # label for x-axis
         self.add_attribute('y_label', None) # label for y-axis
+        self.add_attribute('x_label_fontsize', None)
+        self.add_attribute('y_label_fontsize', None)
         self.add_attribute('x_label_kwargs', {})
         self.add_attribute('y_label_kwargs', {})
 

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -698,6 +698,8 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('ylabel_fontsize', None)
         self.add_attribute('xlabel_kwargs', {})
         self.add_attribute('ylabel_kwargs', {})
+        self.add_attribute('aspect', None)
+        self.add_attribute('aspect_latitude', None)
 
 
     def new_plotitem(self, name=None, plot_type=None):

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -576,6 +576,8 @@ class ClawPlotFigure(clawdata.ClawData):
         self._plotdata = plotdata           # parent ClawPlotData object
         self.add_attribute('name',name)
         self.add_attribute('figno',figno)
+        self.add_attribute('figsize',None)
+        self.add_attribute('facecolor',None)
         self.add_attribute('kwargs',{})
         self.add_attribute('clf_each_frame',True)
         self.add_attribute('clf_each_gauge',True)
@@ -678,6 +680,20 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('time_label_kwargs', {})  # kwargs for xlabel cmd
         self.add_attribute('time_scale', 1)  # multiplicative factor to rescale t
                                              # e.g. 1/3600. from sec to hours
+
+        # recently added attributes:
+        self.add_attribute('kwargs', {})
+        self.add_attribute('grid', None) # True to add grid() command
+        self.add_attribute('grid_kwargs', {}) # argument to grid() command
+        self.add_attribute('title_kwargs', {}) # e.g. to set fontsize
+        self.add_attribute('title_t_format', None) # format for t in title
+        self.add_attribute('xticks_kwargs', {}) # e.g. to set fontsize
+        self.add_attribute('yticks_kwargs', {}) # e.g. to set fontsize
+        self.add_attribute('x_label', None) # label for x-axis
+        self.add_attribute('y_label', None) # label for y-axis
+        self.add_attribute('x_label_kwargs', {})
+        self.add_attribute('y_label_kwargs', {})
+
 
     def new_plotitem(self, name=None, plot_type=None):
         # Create a new entry in self.plotitem_dict
@@ -800,6 +816,7 @@ class ClawPlotItem(clawdata.ClawData):
             self.add_attribute('colorbar_label',None)
             self.add_attribute('colorbar_ticks', None)
             self.add_attribute('colorbar_tick_labels',None)
+            self.add_attribute('colorbar_extend',None)
             self.add_attribute('colorbar_kwargs',{})
             self.add_attribute('kwargs',{})
             amr_attributes = """celledges_show celledges_color data_show

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -701,6 +701,7 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('ylabel_kwargs', {})
         self.add_attribute('aspect', None)
         self.add_attribute('aspect_latitude', None)
+        self.add_attribute('useOffset', None)
 
 
     def new_plotitem(self, name=None, plot_type=None):

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -677,6 +677,7 @@ class ClawPlotAxes(clawdata.ClawData):
 
         # attributes for gauge plots
         self.add_attribute('time_label', 'time')  # for time axis in gauges
+        self.add_attribute('time_label_fontsize', None)
         self.add_attribute('time_label_kwargs', {})  # kwargs for xlabel cmd
         self.add_attribute('time_scale', 1)  # multiplicative factor to rescale t
                                              # e.g. 1/3600. from sec to hours

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -481,14 +481,14 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
             if plotaxes.yticks_kwargs != {}:
                 plt.yticks(**plotaxes.yticks_kwargs)
 
-            if plotaxes.x_label is not None:
-                if plotaxes.x_label_fontsize is not None:
-                    plotaxes.x_label_kwargs['fontsize'] = plotaxes.x_label_fontsize
-                plt.xlabel(plotaxes.x_label, **plotaxes.x_label_kwargs)
-            if plotaxes.y_label is not None:
-                if plotaxes.y_label_fontsize is not None:
-                    plotaxes.y_label_kwargs['fontsize'] = plotaxes.y_label_fontsize
-                plt.ylabel(plotaxes.y_label, **plotaxes.y_label_kwargs)
+            if plotaxes.xlabel is not None:
+                if plotaxes.xlabel_fontsize is not None:
+                    plotaxes.xlabel_kwargs['fontsize'] = plotaxes.xlabel_fontsize
+                plt.xlabel(plotaxes.xlabel, **plotaxes.xlabel_kwargs)
+            if plotaxes.ylabel is not None:
+                if plotaxes.ylabel_fontsize is not None:
+                    plotaxes.ylabel_kwargs['fontsize'] = plotaxes.ylabel_fontsize
+                plt.ylabel(plotaxes.ylabel, **plotaxes.ylabel_kwargs)
 
             # end of loop over plotaxes
         # end of loop over plotfigures

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -480,6 +480,9 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                     except:
                         pass  # let axis be set automatically
 
+            if plotaxes.useOffset is not None:
+                plt.ticklabel_format(useOffset = plotaxes.useOffset)
+
             if plotaxes.grid:
                 plt.grid(**plotaxes.grid_kwargs)
 

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -397,12 +397,24 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                 pass
             else:
                 if plotaxes.title_with_t:
-                    if 'h:m:s' in plotaxes.title:
-                        # special case: replace this by time in
-                        # hours:minutes:seconds (assuming original t in seconds)
-                        # particularly useful in GeoClaw
-                        from datetime import timedelta
-                        t_str = str(timedelta(seconds=t))
+                    if 'd:h:m:s' in plotaxes.title:
+                        #from datetime import timedelta
+                        #t_str = str(timedelta(seconds=t))
+                        #title_str = plotaxes.title.replace('d:h:m:s',t_str)
+
+                        # formats the same as above but doesn't use datetime:
+                        days, remainder = divmod(t, 24*3600)
+                        hours, remainder = divmod(remainder, 3600)
+                        minutes, seconds = divmod(remainder, 60)
+                        t_str = '%i days, %i:%i:%i' \
+                                % (days,hours,minutes,seconds)
+                        title_str = plotaxes.title.replace('d:h:m:s',t_str)
+
+                    elif 'h:m:s' in plotaxes.title:
+                        # keep total hours, not days
+                        hours, remainder = divmod(t, 3600)
+                        minutes, seconds = divmod(remainder, 60)
+                        t_str = '%i:%i:%i' % (hours,minutes,seconds)
                         title_str = plotaxes.title.replace('h:m:s',t_str)
 
                     elif plotaxes.title_t_format:

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -490,6 +490,12 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                     plotaxes.ylabel_kwargs['fontsize'] = plotaxes.ylabel_fontsize
                 plt.ylabel(plotaxes.ylabel, **plotaxes.ylabel_kwargs)
 
+            if plotaxes.aspect_latitude is not None:
+                plt.gca().set_aspect(1./np.cos(plotaxes.aspect_latitude \
+                            * np.pi/180))
+            elif plotaxes.aspect is not None:
+                plt.gca().set_aspect(plotaxes.aspect)
+
             # end of loop over plotaxes
         # end of loop over plotfigures
 

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -419,11 +419,14 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
                         title_str = "%s at time t = %14.8e" \
                                   % (plotaxes.title,t)
 
-                    plt.title(title_str, **plotaxes.title_kwargs)
 
                 else:
                     # omit t from title:
-                    plt.title(plotaxes.title, **plotaxes.title_kwargs)
+                    title_str = plotaxes.title
+
+                if plotaxes.title_fontsize is not None:
+                    plotaxes.title_kwargs['fontsize'] = plotaxes.title_fontsize
+                plt.title(title_str, **plotaxes.title_kwargs)
 
             # call an afteraxes function if present:
             afteraxes =  getattr(plotaxes, 'afteraxes', None)
@@ -468,14 +471,23 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
             if plotaxes.grid:
                 plt.grid(**plotaxes.grid_kwargs)
 
-            if plotaxes.xticks_kwargs is not None:
+            if plotaxes.xticks_fontsize is not None:
+                plotaxes.xticks_kwargs['fontsize'] = plotaxes.xticks_fontsize
+            if plotaxes.xticks_kwargs != {}:
                 plt.xticks(**plotaxes.xticks_kwargs)
-            if plotaxes.yticks_kwargs is not None:
+
+            if plotaxes.yticks_fontsize is not None:
+                plotaxes.yticks_kwargs['fontsize'] = plotaxes.yticks_fontsize
+            if plotaxes.yticks_kwargs != {}:
                 plt.yticks(**plotaxes.yticks_kwargs)
 
             if plotaxes.x_label is not None:
+                if plotaxes.x_label_fontsize is not None:
+                    plotaxes.x_label_kwargs['fontsize'] = plotaxes.x_label_fontsize
                 plt.xlabel(plotaxes.x_label, **plotaxes.x_label_kwargs)
             if plotaxes.y_label is not None:
+                if plotaxes.y_label_fontsize is not None:
+                    plotaxes.y_label_kwargs['fontsize'] = plotaxes.y_label_fontsize
                 plt.ylabel(plotaxes.y_label, **plotaxes.y_label_kwargs)
 
             # end of loop over plotaxes

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -280,7 +280,8 @@ def plotgauge(gaugeno, plotdata, verbose=False):
             # end of loop over plotitems
 
     
-            pylab.title("%s at gauge %s" % (plotaxes.title,gaugeno))
+            title_str = "%s at gauge %s" % (plotaxes.title,gaugeno)
+            pylab.title(title_str, **plotaxes.title_kwargs)
     
             if plotaxes.time_label is not None:
                 pylab.xlabel(plotaxes.time_label, **plotaxes.time_label_kwargs)
@@ -318,6 +319,16 @@ def plotgauge(gaugeno, plotdata, verbose=False):
                 except:
                     pass  # let axis be set automatically
     
+            if plotaxes.grid:
+                pylab.grid(**plotaxes.grid_kwargs)
+ 
+            if plotaxes.xticks_kwargs is not None:
+                pylab.xticks(**plotaxes.xticks_kwargs)
+            if plotaxes.yticks_kwargs is not None:
+                pylab.yticks(**plotaxes.yticks_kwargs)
+
+            if plotaxes.y_label is not None:
+                pylab.ylabel(plotaxes.y_label, **plotaxes.y_label_kwargs)
 
             # end of loop over plotaxes
             

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -286,6 +286,9 @@ def plotgauge(gaugeno, plotdata, verbose=False):
             pylab.title(title_str, **plotaxes.title_kwargs)
     
             if plotaxes.time_label is not None:
+                if plotaxes.time_label_fontsize is not None:
+                    plotaxes.time_label_kwargs['fontsize'] = \
+                                    plotaxes.time_label_fontsize
                 pylab.xlabel(plotaxes.time_label, **plotaxes.time_label_kwargs)
     
     

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -220,6 +220,9 @@ def plotgauge(gaugeno, plotdata, verbose=False):
             # use Clawpack's default bg color (tan)
             plotfigure.kwargs['facecolor'] = '#ffeebb'   
 
+        if plotfigure.figsize is not None:
+            plotfigure.kwargs['figsize'] = plotfigure.figsize
+
         # create figure and set handle:
         plotfigure._handle = pylab.figure(num=figno, **plotfigure.kwargs)
 

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -281,6 +281,8 @@ def plotgauge(gaugeno, plotdata, verbose=False):
 
     
             title_str = "%s at gauge %s" % (plotaxes.title,gaugeno)
+            if plotaxes.title_fontsize is not None:
+                plotaxes.title_kwargs['fontsize'] = plotaxes.title_fontsize
             pylab.title(title_str, **plotaxes.title_kwargs)
     
             if plotaxes.time_label is not None:
@@ -327,8 +329,10 @@ def plotgauge(gaugeno, plotdata, verbose=False):
             if plotaxes.yticks_kwargs is not None:
                 pylab.yticks(**plotaxes.yticks_kwargs)
 
-            if plotaxes.y_label is not None:
-                pylab.ylabel(plotaxes.y_label, **plotaxes.y_label_kwargs)
+            if plotaxes.ylabel is not None:
+                if plotaxes.ylabel_fontsize is not None:
+                    plotaxes.ylabel_kwargs['fontsize'] = plotaxes.ylabel_fontsize
+                pylab.ylabel(plotaxes.ylabel, **plotaxes.ylabel_kwargs)
 
             # end of loop over plotaxes
             


### PR DESCRIPTION
I added new attributes to `ClawPlotFIgure` and `ClawPlotAxes` to simplify doing various things in `setplot.py`, all of which could be done using `kwargs` and/or `afteraxes` commands, but these are things I do so frequently that I think they should be made simpler.  

I think it is all backward compatible, it just makes some things easier.

The figure below shows a new version of a plot from the standard chile2010 example, using this modified setplot.py that takes advantage of some of the new attributes: https://github.com/rjleveque/geoclaw/blob/plot_updates/examples/tsunami/chile2010/setplot.py

Note in particular:
- white background
- axes labeled Longitude and Latitude with appropriate fontsize
- the title and tick labels also have the fontsize set more easily
- title has time in hour:minute:second notation
- the colorbar has arrows at top and bottom (`extend = 'both'`) to show that waves may be larger than limits of colorbar

![chile2010_frame5](https://github.com/clawpack/visclaw/assets/720122/50df01a5-455f-409b-942e-87c3301f00ca)

Compare to http://www.clawpack.org/gallery/_static/geoclaw/examples/tsunami/chile2010/_plots/frame0005fig0.html