### PR TITLE
Add meson build.

### DIFF
--- a/src/python/visclaw/meson.build
+++ b/src/python/visclaw/meson.build
@@ -1,0 +1,34 @@
+package = 'clawpack.visclaw'
+pkg_dir = join_paths(package.split('.'))
+
+python_sources = [
+  'Iplotclaw.py',
+  '__init__.py',
+  'animation_tools.py',
+  'colormaps.py',
+  'data.py',
+  'frametools.py',
+  'gauge_interp.py',
+  'gaugetools.py',
+  'geoplot.py',
+  'gridtools.py',
+  'ianimate.py',
+  'iplot.py',
+  'ipyclaw.py',
+  'legend_tools.py',
+  'make_anim.py',
+  'multiframetools.py',
+  'particle_tools.py',
+  'plot_timing_stats.py',
+  'plotclaw.py',
+  'plotfg.py',
+  'plotpages.py',
+  'plottools.py',
+  'setplot_default.py',
+]
+
+py.install_sources(
+  python_sources,
+  subdir: pkg_dir,
+)
+


### PR DESCRIPTION
Only installs python files for now.

This is the first phase of switching to meson (away from distutils). This allows meson to install python files only. The second phase is to add compilation of the Fortran extensions (for Python).

For now, this will have no effect since the meson build is not enabled at the top level.