### PR TITLE
Add ability to pass norm and alpha values to imshow

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -845,6 +845,7 @@ class ClawPlotItem(clawdata.ClawData):
                 self.add_attribute('imshow_cmin',None)
                 self.add_attribute('imshow_cmax',None)
                 self.add_attribute('imshow_norm', None)
+                self.add_attribute('imshow_alpha', None)
 
 
             elif plot_type in ['2d_contour', '2d_contourf']:

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -844,6 +844,7 @@ class ClawPlotItem(clawdata.ClawData):
                 self.add_attribute('imshow_cmap',colormaps.yellow_red_blue)
                 self.add_attribute('imshow_cmin',None)
                 self.add_attribute('imshow_cmax',None)
+                self.add_attribute('imshow_norm', None)
 
 
             elif plot_type in ['2d_contour', '2d_contourf']:

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -812,7 +812,7 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
              'celledges_show','celledges_color','patch_bgcolor',
              'patchedges_show','patchedges_color','add_colorbar',
              'pcolor_cmap','pcolor_cmin','pcolor_cmax',
-             'imshow_cmap','imshow_cmin','imshow_cmax',
+             'imshow_cmap','imshow_cmin','imshow_cmax','imshow_norm',
              'contour_levels','contour_nlevels','contour_min','contour_max',
              'contour_colors','contour_cmap','contour_show',
              'fill_cmap','fill_cmin','fill_cmax','fill_colors',
@@ -903,7 +903,11 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
                 pp['imshow_cmin'] = np.min(var)
             if pp['imshow_cmax'] in ['auto',None]:
                 pp['imshow_cmax'] = np.max(var)
-            color_norm = Normalize(pp['imshow_cmin'],pp['imshow_cmax'],clip=True)
+
+            if pp['imshow_norm'] is None:
+                color_norm = pp['imshow_norm']
+            else:
+                color_norm = Normalize(pp['imshow_cmin'],pp['imshow_cmax'],clip=True)
 
             xylimits = (X_edge[0,0],X_edge[-1,-1],Y_edge[0,0],Y_edge[-1,-1])
             pobj = plt.imshow(np.flipud(var.T), extent=xylimits, \

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -812,7 +812,8 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
              'celledges_show','celledges_color','patch_bgcolor',
              'patchedges_show','patchedges_color','add_colorbar',
              'pcolor_cmap','pcolor_cmin','pcolor_cmax',
-             'imshow_cmap','imshow_cmin','imshow_cmax','imshow_norm',
+             'imshow_cmap','imshow_cmin','imshow_cmax',
+             'imshow_norm', 'imshow_alpha',
              'contour_levels','contour_nlevels','contour_min','contour_max',
              'contour_colors','contour_cmap','contour_show',
              'fill_cmap','fill_cmin','fill_cmax','fill_colors',
@@ -904,15 +905,17 @@ def plotitem2(framesoln, plotitem, current_data, stateno):
             if pp['imshow_cmax'] in ['auto',None]:
                 pp['imshow_cmax'] = np.max(var)
 
-            if pp['imshow_norm'] is None:
-                color_norm = pp['imshow_norm']
-            else:
+            if pp['imshow_norm'] in ["auto", None]:
                 color_norm = Normalize(pp['imshow_cmin'],pp['imshow_cmax'],clip=True)
-
+            else:
+                color_norm = pp['imshow_norm']
+         
             xylimits = (X_edge[0,0],X_edge[-1,-1],Y_edge[0,0],Y_edge[-1,-1])
             pobj = plt.imshow(np.flipud(var.T), extent=xylimits, \
                     cmap=pp['imshow_cmap'], interpolation='nearest', \
-                    norm=color_norm)
+                    norm=color_norm, \
+                    alpha=pp["imshow_alpha"]
+                    )
 
             if pp['celledges_show']:
                 # This draws cell edges for this level.


### PR DESCRIPTION
I've found it useful to be able to specify a norm object to plotitem for 2d_imshow

e.g., 

```python
plotitem.imshow_norm = mpl.colors.LogNorm(0.001, 10, clip=True)
```
 
Similarly, I've found it useful to provide an alpha value to make an imshow transparent (e.g., on top of a hillshade). 

This PR adds these two features (I'll make an associated PR for the docs shortly).