### PR TITLE
change the default plotfigure.facecolor to white

### DIFF
--- a/src/python/visclaw/colormaps.py
+++ b/src/python/visclaw/colormaps.py
@@ -16,6 +16,9 @@ import numpy
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
+# Clawpack tan color for plotfigure.facecolor if desired (default now 'w'):
+clawpack_tan = '#ffeebb'  
+
 #-------------------------
 def make_colormap(color_list):
 #-------------------------

--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -156,8 +156,11 @@ def plot_frame(framesolns,plotdata,frameno=0,verbose=False):
 
         if (plotfigure.facecolor is None) and \
            ('facecolor' not in plotfigure.kwargs):
-            # use Clawpack's default bg color (tan)
-            plotfigure.kwargs['facecolor'] = '#ffeebb'
+            # Use white as default starting in v5.10.0
+            # To use old default Clawpack tan, in setplot.py set:
+            #     plotfigure.facecolor = \
+            #           clawpack.visclaw.colormaps.clawpack_tan
+            plotfigure.kwargs['facecolor'] = 'w'
         elif plotfigure.facecolor is not None:
             plotfigure.kwargs['facecolor'] = plotfigure.facecolor
 


### PR DESCRIPTION
The default color has been tan, but white looks better on webpages and for publications.

If you want the original color, you can set this for a plot figure in `setplot.py` via:

    from clawpack.visclaw.colormaps import clawpack_tan
    plotfigure.facecolor =  clawpack_tan