### PR TITLE
Add option to write out .mp4 file of animations

### DIFF
--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -242,7 +242,8 @@ def make_rst(anim, file_name='anim.rst',
 
 
 def make_mp4(anim, file_name='anim.mp4',
-              fps=None, embed_frames=True, default_mode='once'):
+              fps=None, embed_frames=True, default_mode='once',
+              dpi=None):
     """
     Take an animation and covert to mp4 file using ffmpeg, which must be
     installed.
@@ -259,7 +260,7 @@ def make_mp4(anim, file_name='anim.mp4',
     if fps is None:
         fps = 3
     writer = animation.writers['ffmpeg'](fps=fps)
-    anim.save(file_name, writer=writer)
+    anim.save(file_name, writer=writer, dpi=dpi)
     print("Created %s" % file_name)
 
 
@@ -409,8 +410,9 @@ def make_anim_outputs_from_plotdir(plotdir='_plots', fignos='all',
 
         if 'mp4' in outputs:
             file_name = file_name_prefix + 'fig%s.mp4' % figno
+
             make_mp4(anim, file_name, fps=fps, \
-                embed_frames=True, default_mode='once')
+                embed_frames=True, default_mode='once', dpi=dpi)
 
         if 'html' in outputs:
             file_name = file_name_prefix + 'fig%s.html' % figno
@@ -423,7 +425,7 @@ def make_anim_outputs_from_plotdir(plotdir='_plots', fignos='all',
                 embed_frames=True, default_mode='once')
 
 
-def animate_from_plotdir(plotdir='_plots', figno=None, figsize=None, 
+def animate_from_plotdir(plotdir='_plots', figno=None, figsize=None,
                          dpi=None, fps=5):
     """
     Use the png files in plotdir to create an animation that is returned.

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -104,13 +104,8 @@ class ClawPlotData(clawdata.ClawData):
 
         self.add_attribute('gif_movie',False)          # make animated gif movie of frames
 
-        self.add_attribute('ffmpeg_movie',False)  # make animated mp4 movie with ffmpeg
-        self.add_attribute('ffmpeg_name', "")
-        self.add_attribute('ffmpeg_global_options', '')
-        self.add_attribute('ffmpeg_input_options', '-y -r 6 -f image2')
-        self.add_attribute('ffmpeg_output_options', '-vcodec libx264 -vf scale=1800:-2 -crf 20 -pix_fmt yuv420p')
-
-
+        self.add_attribute('mp4_movie',False)         # make animated mp4 movie of frames
+        self.add_attribute('movie_name_prefix', 'movie_')
         self.add_attribute('setplot',False)            # Execute setplot.py in plot routine
 
         self.add_attribute('mapc2p',None)              # function to map computational
@@ -696,9 +691,9 @@ class ClawPlotAxes(clawdata.ClawData):
         self.add_attribute('title_fontsize', None)
         self.add_attribute('title_kwargs', {}) # e.g. to set color
         self.add_attribute('title_t_format', None) # format for t in title
-        self.add_attribute('xticks_fontsize', None) 
+        self.add_attribute('xticks_fontsize', None)
         self.add_attribute('xticks_kwargs', {}) # e.g. to set ticks,rotation
-        self.add_attribute('yticks_fontsize', None) 
+        self.add_attribute('yticks_fontsize', None)
         self.add_attribute('yticks_kwargs', {}) # e.g. to set ticks
         self.add_attribute('xlabel', None) # label for x-axis
         self.add_attribute('ylabel', None) # label for y-axis

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -89,7 +89,9 @@ class ClawPlotData(clawdata.ClawData):
         self.add_attribute('html_index_title','Plot Index')   # title at top of index page
         self.add_attribute('html_homelink',None)       # link to here from top of _PlotIndex.html
         self.add_attribute('html_movie','JSAnimation') # make html with java script for movie
-        self.add_attribute('html_movie_width', 500)    # width of movie
+        self.add_attribute('html_movie_width', 500)    # width of movie (not used?)
+        self.add_attribute('html_movie_dpi', 100)      # dpi of movie
+
         self.add_attribute('html_eagle',False)         # use EagleClaw titles on html pages?
 
         self.add_attribute('kml',False)                # make kml plots and a kml file for figures

--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -104,6 +104,13 @@ class ClawPlotData(clawdata.ClawData):
 
         self.add_attribute('gif_movie',False)          # make animated gif movie of frames
 
+        self.add_attribute('ffmpeg_movie',False)  # make animated mp4 movie with ffmpeg
+        self.add_attribute('ffmpeg_name', "")
+        self.add_attribute('ffmpeg_global_options', '')
+        self.add_attribute('ffmpeg_input_options', '-y -r 6 -f image2')
+        self.add_attribute('ffmpeg_output_options', '-vcodec libx264 -vf scale=1800:-2 -crf 20 -pix_fmt yuv420p')
+
+
         self.add_attribute('setplot',False)            # Execute setplot.py in plot routine
 
         self.add_attribute('mapc2p',None)              # function to map computational

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -3077,37 +3077,43 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
             else:
                 png_prefix = plotdata.file_prefix
 
-            outputs = []
-            if plotdata.html_movie == "JSAnimation":
-                outputs.append('html')
-            if plotdata.mp4_movie:
-                outputs.append('mp4')
-
-            # get original dpi and fig shape, if
-            # this ensures that the resolution of the movie is the
-            # same as the frames.
+            # get original fig shape
             figname = plotdata._figname_from_num[figno]
             plotfigure = plotdata.plotfigure_dict[figname]
-
             figkwargs = getattr(plotfigure, 'kwargs', {})
             figsize = getattr(plotfigure, 'figsize', None)
             if figsize is None:
                 figsize = figkwargs.get('figsize', None)
-            dpi = figkwargs.get('dpi', html_movie_dpi)
 
             # make animations
-            animation_tools.make_anim_outputs_from_plotdir(plotdir=plotdir,
-                            #file_name_prefix='movieframe_allframes',
-                            file_name_prefix=plotdata.movie_name_prefix,
-                            png_prefix=png_prefix,
-                            figsize=figsize,
-                            dpi=dpi,
-                            fignos=[figno], outputs=outputs,
-                            raw_html=raw_html)
+            if plotdata.mp4_movie:
+                # use default dpi or get from plotdata
+                # this ensures that if it was set, dpi of mp4 is same as frames.
+                dpi = figkwargs.get('dpi', html_movie_dpi)
+                animation_tools.make_anim_outputs_from_plotdir(plotdir=plotdir,
+                                #file_name_prefix='movieframe_allframes',
+                                file_name_prefix=plotdata.movie_name_prefix,
+                                png_prefix=png_prefix,
+                                figsize=figsize,
+                                dpi=dpi,
+                                fignos=[figno], outputs=['mp4'],
+                                raw_html=raw_html)
+
+            if plotdata.html_movie == "JSAnimation":
+                # use different dpi so that plots do not take over browser width.
+                animation_tools.make_anim_outputs_from_plotdir(plotdir=plotdir,
+                                #file_name_prefix='movieframe_allframes',
+                                file_name_prefix=plotdata.movie_name_prefix,
+                                png_prefix=png_prefix,
+                                figsize=figsize,
+                                dpi=plotdata.html_movie_dpi,
+                                fignos=[figno], outputs=['html'],
+                                raw_html=raw_html)
 
             # Note: setting figsize=None above chooses figsize with aspect
             # ratio based on .png files read in, may fit better on page
-            # 3/21/24 - For MP4 size and dpi are taken from plotdata for each figure.
+            # 3/21/24 - For MP4 size and dpi are taken from plotdata for
+            # each figure.
 
 
     #-----------

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -3095,6 +3095,20 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
             except:
                 print('*** Error creating moviefig%s.gif' % figno)
 
+    #-----------
+    # mp4 movie:
+    #-----------
+    if plotdata.ffmpeg_movie:
+        print('Making movies with ffmpeg.  This may take some time....')
+        for figno in fignos_each_frame:
+            try:
+                cmd = f"ffmpeg {plotdata.ffmpeg_global_options} {plotdata.ffmpeg_input_options} -i frame%4dfig{figno}.png {plotdata.ffmpeg_output_options} {plotdata.ffmpeg_name}moviefig{figno}.mp4"
+                os.system(cmd)
+                print('    Created ffmpeg outputs for figno %s' % figno)
+            except:
+                print('*** Error creating ffmpeg outputs for figno %s' % figno)
+
+
     os.chdir(rootdir)
 
     # print out pointers to html index page:


### PR DESCRIPTION
In my pre-5.0 workflows, I've found it very useful to make .mp4s with ffmpeg. (I know that this somewhat duplicates the workflow in the visclaw.make_anim routines 😬 ).

This PR adds the ffmpeg functionality, and constructs the ffmpeg command as 
```python
f"ffmpeg {plotdata.ffmpeg_global_options} {plotdata.ffmpeg_input_options} -i frame%4dfig{figno}.png {plotdata.ffmpeg_output_options} {plotdata.ffmpeg_name}moviefig{figno}.mp4"
```

to mimic the ffmpeg syntax of:
```
ffmpeg [global_options] {[input_file_options] -i input_url} ... {[output_file_options] output_url} ...
```
https://ffmpeg.org/ffmpeg.html

I've set the input and output options to a set that (after a moderate amount of fiddling) I found worked for my applications.

Happy to improve it based on feedback.