### PR TITLE
Fix 'is' with a literal warning

### DIFF
--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -602,7 +602,7 @@ def plotclaw2kml(plotdata):
     from copy import deepcopy
     from clawpack.geoclaw import kmltools
 
-    if plotdata.format is 'forestclaw':
+    if plotdata.format == 'forestclaw':
         level_base = 0
     else:
         level_base = 1
@@ -1806,7 +1806,7 @@ def massage_frames_data(plot_pages_data):
         fignos = ppd.timeframes_fignos
         fignames = ppd.timeframes_fignames
         prefix = getattr(ppd, 'file_prefix', 'fort')
-        if prefix is 'fort':
+        if prefix == 'fort':
             prefix = getattr(ppd, 'timeframes_prefix', 'frame')
         if prefix != 'frame':
             prefix = prefix + 'frame'


### PR DESCRIPTION
Fixes `SyntaxWarning` that pops up when plotting sometimes with newer versions of Python:
```
.../clawpack/visclaw/src/python/visclaw/plotpages.py:605: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if plotdata.format is 'forestclaw':
...clawpack/visclaw/src/python/visclaw/plotpages.py:1809: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if prefix is 'fort':
```
