### PR TITLE
Make plotpages respect file format specification.

### DIFF
--- a/src/python/visclaw/data.py
+++ b/src/python/visclaw/data.py
@@ -27,7 +27,7 @@ class ClawPlotData(clawdata.ClawData):
     """
 
     # ========== Initialization routine ======================================
-    def __init__(self, controller=None):
+    def __init__(self, controller=None, file_format="ascii"):
         """Initialize a PlotData object
 
         """
@@ -50,8 +50,11 @@ class ClawPlotData(clawdata.ClawData):
         else:
             self.add_attribute('rundir',os.getcwd())     # uses *.data from rundir
             self.add_attribute('outdir',os.getcwd())     # where to find fort.* files
-            self.add_attribute('format','ascii')
-            self.add_attribute('file_prefix','fort')
+            self.add_attribute('format',file_format)
+            if file_format == "petsc":
+                self.add_attribute('file_prefix','claw')
+            else:
+                self.add_attribute('file_prefix','fort')
 
         # This should eventually replace all need for recording the above
         # information

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -46,7 +46,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
     from clawpack.visclaw.data import ClawPlotData
     from clawpack.visclaw import plotpages
 
-    plotdata = ClawPlotData()
+    plotdata = ClawPlotData(file_format=format)
     plotdata.outdir = outdir
     plotdata.plotdir = plotdir
     plotdata.setplot = setplot

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2792,6 +2792,11 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
     plotdata.save_frames = False
 
+    if format == "petsc":
+        plotdata.file_prefix = "claw"
+        file_extension = "ptc"
+    else:
+        file_extension = "q"
     if plotdata.file_prefix is None:
         plotdata.file_prefix = 'fort'
 
@@ -2921,21 +2926,11 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
     pngfile = {}
     frametimes = {}
 
-    #import pdb; pdb.set_trace()
-    for file in glob.glob(plotdata.file_prefix + '.q*'):
+    for file in glob.glob(plotdata.file_prefix + '.'+file_extension+r'\d{4}'):
         frameno = int(file[-4:])
         fortfile[frameno] = file
         for figno in fignos_each_frame:
             pngfile[frameno,figno] = 'frame' + file[-4:] + 'fig%s.png' % figno
-
-    #DK: In PetClaw, we don't output fort.q* files.  Instead count the
-    #claw.pkl* files.
-    if len(fortfile) == 0:
-        for file in glob.glob('claw.pkl*'):
-            frameno = int(file[9:12])
-            fortfile[frameno] = file
-            for figno in fignos_each_frame:
-                pngfile[frameno,figno] = 'frame' + file[-4:] + 'fig%s.png' % figno
 
     if len(fortfile) == 0:
         print('*** Warning: No fort.q or claw.pkl files found in directory ', os.getcwd())


### PR DESCRIPTION
This fixes a bug that caused visclaw to look for fort.q* files even when the user specified the file format as petsc. Now it correctly looks for claw.ptc* files.