### PR TITLE
Remove Cygwin Code

### DIFF
--- a/src/python/visclaw/frametools.py
+++ b/src/python/visclaw/frametools.py
@@ -1349,18 +1349,6 @@ def printframes(plotdata=None, verbose=True):
 
     rootdir = os.getcwd()
 
-    # annoying fix needed when EPD is used for plotting under cygwin:
-    cw_path = r'C:\cygwin'
-    if rootdir[0:9] == cw_path and outdir[0:9] != cw_path:
-        outdir = cw_path + outdir
-        plotdata.outdir = outdir
-    if rootdir[0:9] == cw_path and rundir[0:9] != cw_path:
-        rundir = cw_path + rundir
-        plotdata.rundir = rundir
-    if rootdir[0:9] == cw_path and plotdir[0:9] != cw_path:
-        plotdir = cw_path + plotdir
-        plotdata.plotdir = plotdir
-
     try:
         os.chdir(rundir)
     except OSError:

--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -651,17 +651,6 @@ def printgauges(plotdata=None, verbose=True):
 
     rootdir = os.getcwd()
 
-    # annoying fix needed when EPD is used for plotting under cygwin:
-    if rootdir[0:9] == r'C:\cygwin' and outdir[0:9] != r'C:\cygwin':
-        outdir = r'C:\cygwin' + outdir
-        plotdata.outdir = outdir
-    if rootdir[0:9] == r'C:\cygwin' and rundir[0:9] != r'C:\cygwin':
-        rundir = r'C:\cygwin' + rundir
-        plotdata.rundir = rundir
-    if rootdir[0:9] == r'C:\cygwin' and plotdir[0:9] != r'C:\cygwin':
-        plotdir = r'C:\cygwin' + plotdir
-        plotdata.plotdir = plotdir
-
     try:
         os.chdir(rundir)
     except:

--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -27,10 +27,6 @@ import subprocess
 
 import clawpack.visclaw.frametools as frametools
 
-if sys.platform in ['win32','cygwin']:
-    pypath = 'C:/cygwin' + os.environ['CLAW'] + '/python'
-    sys.path.append(pypath)
-
 
 def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py',
              format='ascii', msgfile='', frames=None, verbose=False):

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -2866,17 +2866,6 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
 
     rootdir = os.getcwd()
 
-    # annoying fix needed when EPD is used for plotting under cygwin:
-    if rootdir[0:9] == 'C:\cygwin' and outdir[0:9] != 'C:\cygwin':
-        outdir = 'C:\cygwin' + outdir
-        plotdata.outdir = outdir
-    if rootdir[0:9] == 'C:\cygwin' and rundir[0:9] != 'C:\cygwin':
-        rundir = 'C:\cygwin' + rundir
-        plotdata.rundir = rundir
-    if rootdir[0:9] == 'C:\cygwin' and plotdir[0:9] != 'C:\cygwin':
-        plotdir = 'C:\cygwin' + plotdir
-        plotdata.plotdir = plotdir
-
     try:
         os.chdir(rundir)
     except:


### PR DESCRIPTION
This PR removes old code that used to be needed when used with Cygwin.  Clawpack has not directly supported Cygwin for a bit and there are better [alternatives](https://learn.microsoft.com/en-us/windows/wsl/).

This was removal was caused by a bunch of errors such as 
```sh
$CLAW/visclaw/src/python/visclaw/plotpages.py:2877: SyntaxWarning: invalid escape sequence '\c'
  plotdir = 'C:\cygwin' + plotdir
```
 from newer versions of Python that do not allow `\c` characters.  This may be able to be modified but I do not have a cygwin installation to test from and this seems as good as any a time to remove the support.