### PR TITLE
Shorten poll interval for process checking to 0.5 seconds

### DIFF
--- a/src/python/visclaw/plotclaw.py
+++ b/src/python/visclaw/plotclaw.py
@@ -102,7 +102,7 @@ def plotclaw(outdir='.', plotdir='_plots', setplot = 'setplot.py', plotdata=None
 
                 process_queue.append(subprocess.Popen(plot_cmd, shell=True))
 
-            poll_interval = 5
+            poll_interval = 0.5
             try:
                 while len(process_queue) > 0:
                     time.sleep(poll_interval)


### PR DESCRIPTION
This seems to address #317.  When multiple processes are used to do plotting a poll timer is used so that the processes are not checked constantly.  This used to be set to 5 seconds, but it turns out this may have been a bit too long.  I am not entirely sure what to set this to, but an order of magnitude less seems a good start as it removes this particular bottleneck.