### PR TITLE
animation_tools fix to sort filenames for making animation

### DIFF
--- a/src/python/visclaw/animation_tools.py
+++ b/src/python/visclaw/animation_tools.py
@@ -269,6 +269,7 @@ def read_images(plotdir, fname_pattern='*.png'):
     import glob, os
     images = []
     files = glob.glob(os.path.join(plotdir, fname_pattern))
+    files.sort() # so they are in the right order when names include frameno
     for file in files:
         im = plt.imread(file)
         images.append(im)


### PR DESCRIPTION
In animation_tools.read_images, so the images are in the right order, assuming zero-padded frameno is part of the fname_pattern.